### PR TITLE
fix: reset version to 0.x and configure semantic-release for pre-1.0 development

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxide"
-version = "1.3.0"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.70"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,10 +173,9 @@ version_variables = []  # Don't update any Python files
 build_command = ""  # Build handled by release workflow
 major_on_zero = false  # Stay in 0.x until production-ready
 tag_format = "v{version}"
-commit_parser = "angular"
+commit_parser = "conventional"  # Use conventional commits parser (angular is deprecated)
 
 [tool.semantic_release.changelog]
-changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = [
     "^chore:",
     "^ci:",
@@ -184,6 +183,9 @@ exclude_commit_patterns = [
     "^style:",
     "^test:",
 ]
+
+[tool.semantic_release.changelog.default_templates]
+changelog_file = "CHANGELOG.md"
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["feat", "fix", "perf", "refactor", "build", "docs"]


### PR DESCRIPTION
## Summary

Fixes the semantic-release version mess by resetting to 0.x development and properly configuring for pre-1.0 mode.

Fixes #41

## Problem

The automated semantic-release workflow incorrectly created v1.x releases (v1.0.0 through v1.3.0) despite the project being in pre-1.0 alpha/beta phase.

**Root cause:** Semantic-release couldn't parse `v0.0.1-alpha` format and jumped to v1.0.0.

## Solution

### 1. Cleanup (completed manually via gh/git CLIs)
- ✅ Deleted erroneous releases: v1.1.1, v1.2.0
- ✅ Deleted erroneous tags: v1.0.0 through v1.3.0 (12 tags total)

### 2. Version Reset (this PR)
- Reset `Cargo.toml` version: `1.3.0` → `0.1.0`
- Latest valid tag remains: `v0.1.0`

### 3. Configuration Fix (this PR)
Updated `pyproject.toml` semantic-release config:
- Changed `commit_parser` from deprecated `angular` to `conventional`
- Moved `changelog_file` to `changelog.default_templates.changelog_file`
- Confirmed `major_on_zero = false` is set (enables proper 0.x mode)

## How 0.x Mode Works

With `major_on_zero = false`:
- `feat:` commits → bump minor: `0.1.0` → `0.2.0`
- `fix:` commits → bump patch: `0.1.0` → `0.1.1`
- `BREAKING CHANGE:` → stays in 0.x until manual 1.0.0 release

## Next Release

After this PR merges, the next automated release will be `v0.2.0` (several `feat:` commits since v0.1.0).

## Testing

- Pre-commit hooks: ✅ Passed
- Configuration validated against semantic-release docs
- Manually verified tag/release cleanup

## Checklist

- [x] Issue exists (#41)
- [x] Erroneous releases/tags deleted
- [x] Cargo.toml version reset to 0.1.0
- [x] pyproject.toml configuration updated
- [x] Commit message references issue
- [x] PR description includes "Fixes #41"