### PR TITLE
fix: disable automated release workflow until v0.x config is fixed

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -1,9 +1,11 @@
 name: Release (Automated)
 
 on:
-  push:
-    branches:
-      - main
+  # Temporarily disabled auto-trigger until v0.x semantic-release config is fixed
+  # See issue #43
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Emergency fix to stop the automated release workflow from creating v1.0.0 releases while it's using the old configuration.

Fixes #43
Blocks: #41 (until this merges first)

## Problem

The automated release workflow just triggered and tried to create **v1.0.0 AGAIN**:
1. Detected upgrade from 0.1.0 to 1.0.0 ❌
2. Created commit "chore(release): 1.0.0"
3. Branch protection blocked push to main ✅
4. But created tag v1.0.0 (deleted manually)

**Why?** PR #42 has the fix, but hasn't merged yet. The workflow runs with the OLD config on every push to main.

## Solution

Temporarily disable the auto-trigger:
- ✅ Comment out `push: branches: main` trigger
- ✅ Keep `workflow_dispatch` for manual releases only
- ✅ Add comment explaining temporary nature

## Re-enable Plan

After this merges:
1. Merge PR #42 (semantic-release config fix)
2. Manually test: `gh workflow run release-automated.yml`
3. Verify it creates 0.2.0 (not 1.x)
4. Re-enable auto-trigger

## Testing

- Pre-commit hooks: ✅ Passed
- YAML syntax: ✅ Valid
- Workflow will only run on manual dispatch now

## Checklist

- [x] Issue exists (#43)
- [x] Deleted erroneous v1.0.0 tag
- [x] Disabled push trigger
- [x] Added explanatory comment
- [x] Commit references issue
- [x] PR includes "Fixes #43"