### PR TITLE
fix: add allow_zero_version=true to semantic-release config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ version_source = "commit"
 version_toml = []  # Don't update pyproject.toml
 version_variables = []  # Don't update any Python files
 build_command = ""  # Build handled by release workflow
+allow_zero_version = true  # Allow 0.x versions (v10+ defaults to false)
 major_on_zero = false  # Stay in 0.x until production-ready
 tag_format = "v{version}"
 commit_parser = "conventional"  # Use conventional commits parser (angular is deprecated)


### PR DESCRIPTION
## Problem

Semantic-release continues to create v1.0.0 releases despite configuration intending to stay in 0.x pre-1.0 development mode.

## Root Cause

In `python-semantic-release` v10.x, the default value of `allow_zero_version` changed from `true` to `false`.

When `allow_zero_version = false`:
- Forces first version to be 1.0.0
- **Ignores `major_on_zero` setting entirely**

Our `pyproject.toml` had `major_on_zero = false` but was missing `allow_zero_version = true`, causing semantic-release to ignore our 0.x intention and always create 1.0.0.

## Solution

Added explicit `allow_zero_version = true` to `[tool.semantic_release]` configuration.

```toml
[tool.semantic_release]
allow_zero_version = true  # Allow 0.x versions (v10+ defaults to false)
major_on_zero = false  # Stay in 0.x until production-ready
```

## Testing

After merging, we should test with:
```bash
gh workflow run release-automated.yml
```

Expected behavior:
- `feat:` commits should bump 0.1.0 → 0.2.0 (not 1.0.0)
- `fix:` commits should bump 0.1.0 → 0.1.1

## References

- [Python Semantic Release Configuration](https://python-semantic-release.readthedocs.io/en/latest/configuration/configuration.html)
- Breaking change in v10.0.0: `allow_zero_version` default changed to `false`

Fixes #45