### PR TITLE
fix: use SEMANTIC_RELEASE_TOKEN and official python-semantic-release action

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -1,21 +1,22 @@
 name: Release (Automated)
 
 on:
-  # Temporarily disabled auto-trigger until v0.x semantic-release config is fixed
-  # See issue #43
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
   contents: write
   id-token: write
+  issues: write
+  pull-requests: write
 
 jobs:
   semantic-release:
-    name: Determine Version & Create Release
+    name: Semantic Release
     runs-on: ubuntu-latest
+    concurrency: release
     outputs:
       released: ${{ steps.release.outputs.released }}
       version: ${{ steps.release.outputs.version }}
@@ -25,7 +26,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v5.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
@@ -48,30 +49,24 @@ jobs:
 
       - name: Python Semantic Release
         id: release
+        uses: python-semantic-release/python-semantic-release@v10.4.1
+        with:
+          github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          git_committer_name: "github-actions[bot]"
+          git_committer_email: "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update Cargo.toml version
+        if: steps.release.outputs.released == 'true'
         run: |
-          # Run semantic-release to determine new version
-          NEW_VERSION=$(uv run semantic-release version --print)
+          VERSION="${{ steps.release.outputs.version }}"
+          echo "Updating Cargo.toml to version $VERSION"
+          cargo set-version "$VERSION"
 
-          if [ "$NEW_VERSION" != "" ]; then
-            echo "New version: $NEW_VERSION"
-            echo "released=true" >> $GITHUB_OUTPUT
-            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-            echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
-
-            # Update Cargo.toml
-            cargo set-version "$NEW_VERSION"
-
-            # Commit and tag
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add Cargo.toml CHANGELOG.md
-            git commit -m "chore(release): $NEW_VERSION"
-            git tag "v$NEW_VERSION"
-            git push origin main --tags
-          else
-            echo "No release needed"
-            echo "released=false" >> $GITHUB_OUTPUT
-          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          git commit --amend --no-edit
+          git push origin main --force-with-lease
 
   build-wheels:
     name: Build wheels on ${{ matrix.platform || matrix.os }} for ${{ matrix.target }}


### PR DESCRIPTION
## Problem

The automated release workflow cannot push to main due to branch protection blocking direct commits. The workflow was using `GITHUB_TOKEN` which cannot bypass branch protection even with `enforce_admins: false`.

## Solution

Following the proven approach from `valid8r`, this PR:

1. **Switches to SEMANTIC_RELEASE_TOKEN** - A Personal Access Token with admin access that can bypass branch protection
2. **Uses official python-semantic-release GitHub Action** - More reliable than CLI approach
3. **Re-enables automatic releases** - Triggers on push to main (was disabled in #44)
4. **Adds concurrency control** - Prevents parallel release builds
5. **Separates Cargo.toml update** - Handles Rust version sync in separate step

## Changes Made

### Workflow Updates

- Changed token from `GITHUB_TOKEN` to `SEMANTIC_RELEASE_TOKEN`
- Switched from manual CLI to `python-semantic-release/python-semantic-release@v10.4.1` action
- Re-enabled `on.push.branches: [main]` trigger
- Added `concurrency: release` to prevent parallel executions
- Added `issues` and `pull-requests` write permissions
- Cargo.toml version update now happens in separate step after semantic-release

### Branch Protection

Already configured (via earlier PRs):
- ✅ `enforce_admins: false` - Allows PAT with admin access to bypass
- ✅ CODEOWNERS-based reviews for external contributors  
- ✅ PR requirement enforced for non-admin pushes

## Required Setup (Before Merging)

**⚠️ IMPORTANT**: This PR requires creating the `SEMANTIC_RELEASE_TOKEN` secret before it will work.

See issue #47 for detailed instructions, but in summary:

1. **Create PAT**: https://github.com/settings/tokens/new
   - Name: `dioxide-semantic-release`
   - Scopes: `repo`, `workflow`
   - Expiration: No expiration (or 1 year with reminder)

2. **Add Secret**: https://github.com/mikelane/dioxide/settings/secrets/actions
   - Name: `SEMANTIC_RELEASE_TOKEN`
   - Value: Paste the PAT

## Testing Plan

After merging and setting up the secret:

1. The automated workflow should trigger on the merge
2. Since PR #46 was a `fix:` commit, it should create v0.2.0
3. Workflow should successfully:
   - ✅ Create release commit and tag
   - ✅ Push to main (bypassing branch protection with PAT)
   - ✅ Build wheels for all platforms
   - ✅ Publish to PyPI
   - ✅ Create GitHub release

## Verification

After successful run:
- Tag `v0.2.0` should exist
- PyPI should have dioxide 0.2.0
- GitHub release should be created
- Cargo.toml should show `version = "0.2.0"`

## References

- Follows valid8r's working configuration
- Fixes #43 (re-enable automated releases)  
- Requires #47 (setup SEMANTIC_RELEASE_TOKEN)
- Builds on #45, #46 (semantic-release 0.x configuration)

Closes #47