### PR TITLE
fix: prevent duplicate workflow runs from semantic-release commits

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -16,6 +16,8 @@ jobs:
   semantic-release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    # Skip if commit is from semantic-release to prevent duplicate runs
+    if: github.event.head_commit.author.name != 'github-actions[bot]'
     concurrency: release
     outputs:
       released: ${{ steps.release.outputs.released }}


### PR DESCRIPTION
## Summary

Fixes #50

Prevents duplicate workflow runs by skipping the release workflow when the commit author is `github-actions[bot]` (semantic-release's committer).

## Problem

The release workflow currently triggers on every push to main, including version bump commits created by semantic-release itself:

1. Developer pushes commit → workflow runs → semantic-release creates version commit
2. Version commit pushes to main → workflow runs again
3. Second run finds no releasable commits, wastes CI minutes

This creates multiple workflow runs for the same logical release.

## Solution

Added conditional to semantic-release job:

```yaml
if: github.event.head_commit.author.name != 'github-actions[bot]'
```

This skips the workflow when semantic-release's own commits trigger it, preventing the loop.

## Testing

- Workflow will run normally for developer commits
- Workflow will skip for semantic-release version commits
- Manual `workflow_dispatch` still works (doesn't have head_commit context)

## Checklist

- [x] Code change made
- [x] No tests needed (workflow configuration)
- [x] Issue #50 created and referenced
- [x] Branch name references issue
- [x] Commit message references issue