### PR TITLE
chore: update all GitHub Actions to latest stable versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
           workspaces: rust
 
       - name: Setup Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6  # v6.0.0
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41  # v7.1.2
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -66,12 +66,12 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6  # v6.0.0
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41  # v7.1.2
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -31,12 +31,12 @@ jobs:
           token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - name: Setup Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6  # v6.0.0
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41  # v7.1.2
 
       - name: Install dependencies
         run: uv sync --group dev
@@ -119,7 +119,7 @@ jobs:
           ref: ${{ needs.semantic-release.outputs.tag }}
 
       - name: Setup Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -132,7 +132,7 @@ jobs:
       # For Linux ARM64 cross-compilation
       - name: Setup QEMU
         if: matrix.target == 'aarch64-unknown-linux-gnu'
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf  # v3.2.0
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
         with:
           platforms: arm64
 
@@ -151,7 +151,7 @@ jobs:
           docker-options: -e CI  # Pass CI env to docker
 
       - name: Upload wheels
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  # v4.5.0
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
         with:
           name: wheels-${{ matrix.platform }}-${{ matrix.target }}-py${{ matrix.python-version }}
           path: dist/*.whl
@@ -170,7 +170,7 @@ jobs:
           ref: ${{ needs.semantic-release.outputs.tag }}
 
       - name: Setup Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
         with:
           python-version: '3.13'
 
@@ -186,7 +186,7 @@ jobs:
           args: --out dist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  # v4.5.0
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -207,15 +207,15 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6  # v6.0.0
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41  # v7.1.2
 
       - name: Download wheels
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           pattern: wheels-*
           path: dist
@@ -248,21 +248,21 @@ jobs:
 
     steps:
       - name: Download all wheels
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           pattern: wheels-*
           path: dist
           merge-multiple: true
 
       - name: Download sdist
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           pattern: sdist
           path: dist
           merge-multiple: true
 
       - name: Setup Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
         with:
           python-version: '3.13'
 
@@ -289,14 +289,14 @@ jobs:
           ref: ${{ needs.semantic-release.outputs.tag }}
 
       - name: Download all wheels
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           pattern: wheels-*
           path: dist
           merge-multiple: true
 
       - name: Download sdist
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           pattern: sdist
           path: dist
@@ -312,7 +312,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.2.0
+        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe  # v2.4.2
         with:
           tag_name: ${{ needs.semantic-release.outputs.tag }}
           body_path: release_notes.md


### PR DESCRIPTION
## Summary
Comprehensive audit and update of ALL GitHub Actions to their latest stable versions with SHA-pinned security.

## Changes

### Major Version Upgrades

**actions/setup-python: v5.3.0 → v6.0.0**
- Old SHA: `0b93645e9fea7318ecaed2b359559ac225c90a2b`
- New SHA: `e797f83bcb11b83ae66e0230d6156d7c80228e7c`
- Updated in: `ci.yml`, `release-automated.yml`

**astral-sh/setup-uv: v6.0.0 → v7.1.2**
- Old SHA: `557e51de59eb14aaaba2ed9621916900a91d50c6`
- New SHA: `85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41`
- Updated in: `ci.yml`, `release-automated.yml`

**actions/upload-artifact: v4.5.0 → v5.0.0**
- Old SHA: `6f51ac03b9356f520e9adb1b1b7802705f340c2b`
- New SHA: `330a01c490aca151604b8cf639adc76d48f6c5d4`
- Updated in: `release-automated.yml`
- Breaking change: Artifacts v5 introduces improved performance and new immutable architecture

**actions/download-artifact: v4.3.0 → v6.0.0**
- Old SHA: `d3f86a106a0bac45b974a628896c90dbdf5c8093`
- New SHA: `018cc2cf5baa6db3ef3c5f8a56943fffe632ef53`
- Updated in: `release-automated.yml`

### Minor/Patch Upgrades

**docker/setup-qemu-action: v3.2.0 → v3.7.0**
- Old SHA: `49b3bc8e6bdd4a60e6116a5414239cba5943d3cf`
- New SHA: `c7c53464625b32c7a7e944ae62b3e17d2b600130`
- Updated in: `release-automated.yml`

**softprops/action-gh-release: v2.2.0 → v2.4.2**
- Old SHA: `c062e08bd532815e2082a85e87e3ef29c3e6d191`
- New SHA: `5be0e66d93ac7ed76da52eca8bb058f665c3a5fe`
- Updated in: `release-automated.yml`

### Already on Latest Versions (No Update Needed)
- ✅ actions/checkout: v5.0.0
- ✅ actions/github-script: v7.0.1
- ✅ Swatinem/rust-cache: v2.8.1
- ✅ codecov/codecov-action: v5.5.1
- ✅ PyO3/maturin-action: v1.49.4
- ✅ python-semantic-release/python-semantic-release: v10.4.1
- ✅ dtolnay/rust-toolchain: @stable (rolling release)

## Audit Process
1. Identified all GitHub Actions used across all workflows
2. Queried GitHub API for latest stable releases
3. Retrieved and verified commit SHAs for each release tag
4. Updated workflows with new versions and SHA pins
5. Verified all SHAs match official release tags

## Testing
- All pre-commit hooks passed (YAML validation, trailing whitespace, etc.)
- CI will run full test suite on PR

## Security
All actions are SHA-pinned for supply chain security and immutability.

## Workflows Updated
- `.github/workflows/ci.yml`
- `.github/workflows/release-automated.yml`
- `.github/workflows/issue-triage.yml` (audited, no updates needed)

Fixes #55