### PR TITLE
chore: configure Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,99 @@
+version: 2
+
+# Dependabot configuration for automated dependency updates
+# Covers: GitHub Actions, Rust (Cargo), and Python (pip/pyproject.toml)
+
+updates:
+  # =============================================================================
+  # GitHub Actions - Weekly updates, all grouped together
+  # =============================================================================
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    # Group all GitHub Actions updates into a single PR
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "mikelane"
+    open-pull-requests-limit: 10
+
+  # =============================================================================
+  # Rust Dependencies (Cargo.toml) - Weekly updates with smart grouping
+  # =============================================================================
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    # Group Rust dependencies by update type
+    groups:
+      # Patch and minor updates together (safer)
+      rust-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      # Major updates separate (need more careful review)
+      rust-major:
+        update-types:
+          - "major"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "rust"
+    reviewers:
+      - "mikelane"
+    open-pull-requests-limit: 10
+
+  # =============================================================================
+  # Python Dependencies (pyproject.toml) - Weekly updates with dev/prod split
+  # =============================================================================
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    # Group Python dependencies intelligently
+    groups:
+      # Production dependencies - minor/patch together
+      python-prod:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      # Development dependencies - all together
+      python-dev:
+        dependency-type: "development"
+      # Major updates separate for careful review
+      python-major:
+        update-types:
+          - "major"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"
+    reviewers:
+      - "mikelane"
+    open-pull-requests-limit: 10
+    # Allow dependencies from both standard and custom registries
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
## Summary
Configures comprehensive Dependabot automation for all dependency ecosystems in the dioxide repository.

## What This Adds

A fully-configured `.github/dependabot.yml` that automates dependency updates across:
- **GitHub Actions** (13 actions currently in use)
- **Rust dependencies** (Cargo.toml)
- **Python dependencies** (pyproject.toml)

## Configuration Details

### Update Schedule
- **Frequency**: Weekly (every Monday @ 9:00 AM PST)
- **Max open PRs**: 10 per ecosystem
- **Auto-assignment**: PRs assigned to @mikelane

### Smart Grouping Strategy

#### GitHub Actions
- **All actions grouped**: One PR for all action updates
- Reduces noise, easier to review collectively

#### Rust (Cargo)
- **Minor/patch updates**: Grouped together (safer, backward-compatible)
- **Major updates**: Separate PR (requires careful review)

#### Python (pip)
- **Production deps**: Grouped by update type (minor/patch together)
- **Development deps**: All grouped together
- **Major updates**: Separate PR (potential breaking changes)

### Automation Benefits

**Security:**
- Automatic security patch detection
- No manual dependency monitoring needed
- Faster response to vulnerabilities

**Maintenance:**
- Zero manual effort for routine updates
- Conventional commit format (`chore(deps)`)
- Proper labeling for filtering

**PR Management:**
- Grouped updates reduce PR volume
- Smart grouping by safety/impact
- Auto-assigned for review

## Example PRs You'll See

**Weekly Monday morning:**
```
1. chore(deps): update github-actions (all actions)
2. chore(deps): update rust-minor-patch dependencies
3. chore(deps): update python-prod dependencies  
4. chore(deps): update python-dev dependencies
```

**Only when major updates available:**
```
5. chore(deps): update rust-major dependencies
6. chore(deps): update python-major dependencies
```

## Labels Added
- `dependencies` - All Dependabot PRs
- `github-actions` - Action updates
- `rust` - Rust dependency updates
- `python` - Python dependency updates

## Configuration Testing

The YAML syntax has been validated by pre-commit hooks and GitHub will validate the schema when merged.

## What Happens After Merge

1. **Immediate**: Dependabot starts monitoring dependencies
2. **First Monday**: First batch of PRs (if updates available)
3. **Ongoing**: Weekly checks every Monday
4. **Security**: Immediate PRs for critical vulnerabilities (bypasses schedule)

## Compatibility

This configuration is compatible with:
- Rust/Python hybrid projects ✓
- Maturin build system ✓
- uv package manager ✓
- GitHub Actions SHA pinning ✓

**Note**: Dependabot handles this stack better than Renovate for Rust+Python+Maturin projects (Renovate has known issues with hybrid builds).

## Future Enhancements

If needed, we can add:
- Custom ignore rules for specific dependencies
- Version pinning strategies
- Additional grouping rules
- Schedule adjustments

Fixes #57