### PR TITLE
Switch to OIDC-based Codecov authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
   test:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write  # Required for OIDC authentication with Codecov
     strategy:
       fail-fast: false
       matrix:
@@ -51,12 +53,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7  # v5.5.1
         with:
+          use_oidc: true  # Use OIDC authentication instead of token
           files: ./coverage.xml
           flags: python-${{ matrix.python-version }}
           name: dioxide
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   lint-python:
     name: Lint Python


### PR DESCRIPTION
## Description

Replaces token-based Codecov authentication with OIDC (OpenID Connect) for secure, tokenless uploads.

## Changes

- ✅ Add `id-token: write` permission to test job in CI workflow
- ✅ Enable `use_oidc: true` in `codecov-action` configuration
- ✅ Remove dependency on `CODECOV_TOKEN` secret

## Benefits

- **No token management**: No need to create, store, or rotate `CODECOV_TOKEN` secrets
- **More secure**: Short-lived OIDC tokens instead of long-lived secrets
- **Simpler**: Zero secrets configuration needed
- **Best practices**: Aligns with GitHub's trusted publishing pattern (same as PyPI)

## Testing

CI will run automatically. The Codecov upload step should successfully authenticate via OIDC without requiring the `CODECOV_TOKEN` secret.

## Post-Merge Cleanup

After confirming OIDC works correctly, the `CODECOV_TOKEN` secret can be safely deleted from repository secrets.

## References

- Codecov OIDC docs: https://docs.codecov.com/docs/github-oidc-bundle-analysis
- codecov-action v5: https://github.com/codecov/codecov-action

Fixes #59