### PR TITLE
docs: add migration guide link to README (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ pip install dioxide
 - **Current Work**: v0.0.2-alpha - MLP API Realignment (breaking changes)
 - **Next Milestone**: v0.1.0-beta - MLP Complete (API freeze) - Mid-December 2025
 
+**Migrating from v0.0.1-alpha?** See [MIGRATION.md](MIGRATION.md) for the complete migration guide.
+
 See [ROADMAP.md](ROADMAP.md) for detailed timeline and [Issues](https://github.com/mikelane/dioxide/issues) for current work.
 
 ## Vision


### PR DESCRIPTION
## Summary

Adds a prominent link to MIGRATION.md in the Status section of README.md.

## Context

Closes #101 - Create migration guide for v0.0.1-alpha to v0.0.2-alpha

The MIGRATION.md file was already created comprehensively in a previous PR. This PR adds the final missing piece: a link from README.md to make the migration guide easily discoverable.

## Changes

- Added migration guide link in README.md Status section with call-to-action: "Migrating from v0.0.1-alpha? See MIGRATION.md for the complete migration guide."

## MIGRATION.md Verification

The existing MIGRATION.md file meets all acceptance criteria from #101:

- ✅ Comprehensive migration guide exists
- ✅ All API changes documented with before/after examples
- ✅ Step-by-step migration instructions (checklist provided)
- ✅ Common patterns covered (complete migration example)
- ✅ Troubleshooting section included
- ✅ Links to full documentation
- ✅ **NOW** Referenced from README.md (this PR)

## Testing

- ✅ Verified MIGRATION.md contains accurate code examples
- ✅ Verified link renders correctly in GitHub markdown
- ✅ All before/after examples match actual v0.0.1 and v0.0.2 APIs

Fixes #101