### PR TITLE
feat: add docs dependency group to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,15 @@ test = [
     "libcst>=1.8.6",
     "mutmut>=3.2.3",
 ]
+docs = [
+    "linkify-it-py>=2.0.0",
+    "myst-parser>=4.0.1",
+    "sphinx>=8.2.3",
+    "sphinx-autoapi>=3.6.0",
+    "sphinx-autodoc-typehints>=3.2.0",
+    "sphinx-copybutton>=0.5.2",
+    "sphinx-rtd-theme>=3.0.2",
+]
 
 [tool.semantic_release]
 version_source = "commit"


### PR DESCRIPTION
## Summary

Adds a `docs` dependency group to `pyproject.toml` with all necessary Sphinx and documentation dependencies, following the pattern from the valid8r project.

## Changes

- Added `docs` dependency group to `[dependency-groups]` section
- Includes the following documentation dependencies:
  - linkify-it-py>=2.0.0
  - myst-parser>=4.0.1  
  - sphinx>=8.2.3
  - sphinx-autoapi>=3.6.0
  - sphinx-autodoc-typehints>=3.2.0
  - sphinx-copybutton>=0.5.2
  - sphinx-rtd-theme>=3.0.2

## Verification

- All dependencies install successfully via `uv sync --group docs`
- All tests pass (201 tests)
- All quality checks pass

## Installation

To install documentation dependencies:

```bash
uv sync --group docs
```

Fixes #140