### PR TITLE
feat: configure ReadTheDocs for automated doc builds (#142)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file for Dioxide
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  commands:
+    # Install uv
+    - pip install uv
+    # Install all dependencies including the project itself
+    - uv sync --group docs
+    # Let uv run Sphinx to avoid dependency conflicts
+    - uv run sphinx-build -b html docs $READTHEDOCS_OUTPUT/html
+
+# Build documentation formats
+formats:
+  - pdf
+  - epub


### PR DESCRIPTION
## Summary

Configures ReadTheDocs for automated documentation builds and deployment.

## Changes

- Created `.readthedocs.yaml` in repository root
- Configured version 2 of ReadTheDocs config format
- Set build OS to ubuntu-22.04
- Set Python version to 3.11
- Configured build commands:
  - Install uv via pip
  - Run `uv sync --group docs` to install dependencies
  - Run `uv run sphinx-build -b html docs $READTHEDOCS_OUTPUT/html`
- Enabled PDF and EPUB format generation
- Followed pattern from valid8r project

## Testing

- Tested locally by simulating ReadTheDocs build
- Build succeeded with expected output
- Pre-commit hooks pass

## Next Steps

After this PR merges:
1. Configure ReadTheDocs webhook on GitHub repository
2. Import dioxide project to ReadTheDocs
3. Verify automated builds trigger on commits
4. Update README.md with ReadTheDocs badge

Fixes #142