### PR TITLE
feat: add Scope.REQUEST enum value

### DIFF
--- a/python/dioxide/scope.py
+++ b/python/dioxide/scope.py
@@ -75,3 +75,21 @@ class Scope(str, Enum):
     - Stateful components that shouldn't be shared
     - Objects with per-request lifecycle
     """
+
+    REQUEST = 'request'
+    """New instance created per request scope.
+
+    Similar to FACTORY but intended for request-scoped contexts like
+    web frameworks where the same instance should be reused within a
+    single request but fresh instances created for each new request.
+
+    Use for:
+    - Request-scoped services in web frameworks
+    - Per-request database sessions
+    - Request context objects
+    - User authentication/authorization state per request
+
+    Note: Request scope behavior requires integration with a request
+    context provider (e.g., FastAPI dependencies, Flask request context).
+    Without such integration, REQUEST scope behaves like FACTORY.
+    """

--- a/tests/test_adapter_scope.py
+++ b/tests/test_adapter_scope.py
@@ -132,3 +132,33 @@ class DescribeAdapterScope:
 
         # Original instance unchanged
         assert email1.get_sent_count() == 2
+
+
+class DescribeScopeRequestEnum:
+    """Tests for Scope.REQUEST enum value."""
+
+    def it_has_request_scope_value(self) -> None:
+        """Scope.REQUEST exists with value 'request'."""
+        assert Scope.REQUEST.value == 'request'
+
+    def it_can_be_used_with_adapter_decorator(self) -> None:
+        """Request scope can be specified on @adapter.for_() decorator."""
+
+        class RequestPort(Protocol):
+            def get_request_id(self) -> int: ...
+
+        @adapter.for_(RequestPort, profile='request-scope-test', scope=Scope.REQUEST)
+        class RequestScopedAdapter:
+            def get_request_id(self) -> int:
+                return id(self)
+
+        assert hasattr(RequestScopedAdapter, '__dioxide_scope__')
+        assert RequestScopedAdapter.__dioxide_scope__ == Scope.REQUEST
+
+    def it_is_a_valid_member_of_scope_enum(self) -> None:
+        """REQUEST is a valid member of the Scope enum alongside SINGLETON and FACTORY."""
+        scope_members = {member.value for member in Scope}
+        assert 'request' in scope_members
+        assert 'singleton' in scope_members
+        assert 'factory' in scope_members
+        assert len(scope_members) == 3


### PR DESCRIPTION
## Summary

Adds `Scope.REQUEST` enum value to support request-scoped components in web frameworks.

## Changes

- Added `REQUEST = 'request'` to `Scope` enum in `python/dioxide/scope.py`
- Added comprehensive docstring explaining use cases (per-request services, database sessions, authentication state)
- Added 3 new tests in `tests/test_adapter_scope.py`

## Test Results

- 227 tests passed, 5 skipped
- All existing tests remain passing (backward compatible)

## Notes

The Rust implementation in `rust/src/lib.rs` does NOT have a `Scope` enum - it handles scoping through different `Provider` types. The `Scope` enum is purely Python-side, so no Rust changes were needed.

## Part of Epic

This is the first step in the Request Scoping epic (#178). It unlocks #180 (container changes) and subsequent issues.

Fixes #179