### PR TITLE
feat: add warning for empty profile matches in container.scan()

### DIFF
--- a/python/dioxide/container.py
+++ b/python/dioxide/container.py
@@ -356,6 +356,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import logging
 import pkgutil
 from collections.abc import Callable
 from typing import (
@@ -370,6 +371,8 @@ from dioxide.exceptions import (
     AdapterNotFoundError,
     ServiceNotFoundError,
 )
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from dioxide.profile_enum import Profile
@@ -1239,6 +1242,13 @@ class Container:
                     # (This will happen with multiple implementations - we'll handle
                     # profile-based selection in a future iteration)
                     pass
+
+        # Warn if profile was specified but matched zero components
+        if normalized_profile is not None and len(self) == 0:
+            logger.warning(
+                "Profile '%s' matched zero components. Verify @adapter.for_() decorators are correctly applied.",
+                normalized_profile,
+            )
 
     def _create_auto_injecting_factory(self, cls: type[T]) -> Callable[[], T]:
         """Create a factory function that auto-injects dependencies from type hints.

--- a/tests/test_empty_profile_warning.py
+++ b/tests/test_empty_profile_warning.py
@@ -1,0 +1,78 @@
+"""Tests for empty profile warning in container.scan() (Issue #87).
+
+When a profile matches zero components during container.scan(), a warning
+should be logged to help users identify typos or misconfiguration.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol
+
+import pytest
+
+from dioxide import (
+    Container,
+    Profile,
+    adapter,
+)
+
+
+class DescribeContainerScanEmptyProfileWarning:
+    """Tests for warning when profile matches zero components."""
+
+    def it_warns_when_profile_matches_no_components(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Logs warning when profile matches zero components."""
+        container = Container()
+
+        with caplog.at_level(logging.WARNING):
+            container.scan(profile='nonexistent_profile')
+
+        assert 'matched zero components' in caplog.text
+        assert 'nonexistent_profile' in caplog.text
+
+    def it_warns_when_profile_enum_matches_no_components(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Logs warning when Profile enum matches zero components."""
+        container = Container()
+
+        with caplog.at_level(logging.WARNING):
+            container.scan(profile=Profile.STAGING)
+
+        assert 'matched zero components' in caplog.text
+        assert 'staging' in caplog.text.lower()
+
+    def it_does_not_warn_when_profile_matches_components(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Does not log warning when profile matches at least one component."""
+
+        class SomePort(Protocol):
+            def do_something(self) -> None: ...
+
+        @adapter.for_(SomePort, profile=Profile.TEST)
+        class TestAdapter:
+            def do_something(self) -> None:
+                pass
+
+        container = Container()
+
+        with caplog.at_level(logging.WARNING):
+            container.scan(profile=Profile.TEST)
+
+        assert 'matched zero components' not in caplog.text
+
+    def it_does_not_warn_when_no_profile_specified(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Does not log warning when scanning without profile filter."""
+        container = Container()
+
+        with caplog.at_level(logging.WARNING):
+            container.scan()
+
+        assert 'matched zero components' not in caplog.text
+
+    def it_suggests_checking_decorator_usage(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Warning message suggests checking @adapter.for_() decorators."""
+        container = Container()
+
+        with caplog.at_level(logging.WARNING):
+            container.scan(profile='nonexistent')
+
+        assert '@adapter.for_()' in caplog.text or 'decorator' in caplog.text.lower()


### PR DESCRIPTION
## Summary

Adds a warning when `container.scan(profile=...)` matches zero components, helping users identify typos or misconfiguration.

## Changes

- Added logging import and module-level logger in `python/dioxide/container.py`
- Added warning logic at end of `scan()` method
- Created `tests/test_empty_profile_warning.py` with 5 tests

## Warning Message

When a profile matches zero components:
```
Profile 'profile_name' matched zero components. Verify @adapter.for_() decorators are correctly applied.
```

## Test Results

- 234 tests passed (including 5 new tests), 6 skipped
- Pre-commit hooks pass

## Design Decision

Used Python's standard `logging` module so users can:
- Filter/suppress the warning if desired
- Integrate with their existing logging configuration
- See warnings in development without breaking production

Fixes #87