### PR TITLE
fix: sync release test dependencies with CI

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -322,7 +322,9 @@ jobs:
           uv pip install --system --find-links=dist --no-index dioxide
 
       - name: Install test dependencies
-        run: uv pip install --system pytest pytest-cov pytest-asyncio pytest-benchmark mypy
+        # Version constraints match pyproject.toml [dependency-groups].dev to ensure
+        # release tests use the same versions as CI (which uses uv sync --all-extras)
+        run: uv pip install --system "pytest>=8.4.2" "pytest-cov>=7.0.0" "pytest-asyncio>=1.3.0" "pytest-benchmark>=5.2.3" "mypy>=1.18.2"
 
       - name: Run smoke tests
         run: python tests/smoke_test.py


### PR DESCRIPTION
## Summary
Fixes #192

Ensures the release workflow's `test-wheels` job uses the same dependency versions as CI.

## Changes
- Updated test dependencies in `test-wheels` job to use version constraints matching `pyproject.toml`
- Added explicit versions: pytest>=8.4.2, pytest-cov>=7.0.0, pytest-asyncio>=1.3.0, pytest-benchmark>=5.2.3, mypy>=1.18.2

## Test plan
- [ ] CI passes
- [ ] Release workflow test-wheels job has matching deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)