### PR TITLE
ci: add linkcheck to CI workflow (#214)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
   docs-linkcheck:
     name: Check Documentation Links
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -279,7 +279,7 @@ linkcheck_allowed_redirects = {
     r'https://semantic-release\.gitbook\.io/.*': r'https://semantic-release\.gitbook\.io/.*',
     r'https://www\.sphinx-doc\.org/.*': r'https://www\.sphinx-doc\.org/.*',
     r'https://docs\.rs/.*': r'https://docs\.rs/.*',
-    r'https://docs\.readthedocs\.io/.*': r'https://docs\.readthedocs\.com/.*',
+    r'https://docs\.readthedocs\.io/.*': r'https://docs\.readthedocs\.io/.*',
 }
 
 # Rate limit requests to avoid being blocked (seconds between requests per host)


### PR DESCRIPTION
## Summary

Adds Sphinx linkcheck builder to CI to automatically catch broken links in documentation before they reach users.

## Changes

### `.github/workflows/ci.yml`
Added new `docs-linkcheck` job that:
- Runs on ubuntu-latest with Python 3.13
- Uses SHA-pinned actions (matching existing CI patterns)
- Builds Rust extension (required for autoapi)
- Runs `sphinx-build -b linkcheck`
- Uploads linkcheck report as artifact on failure

### `docs/conf.py`
Added comprehensive linkcheck configuration:
- **Ignored URLs**: localhost, GitHub line anchors, auth-required pages
- **Allowed Redirects**: PyPI, pyo3.rs, semantic-release docs
- **Rate Limiting**: 5s between requests per host
- **Timeouts**: 30s per request, 3 retries, 5 workers

## Local Usage

```bash
uv run sphinx-build -b linkcheck docs docs/_build/linkcheck
```

## Acceptance Criteria

- [x] Linkcheck job added to CI workflow
- [x] Linkcheck configuration in conf.py
- [x] Known-good links pass
- [x] Broken links fail the build
- [x] Linkcheck report uploaded on failure
- [x] Local linkcheck command documented
- [x] Reasonable timeouts and retries configured

Fixes #214