### PR TITLE
ci: update GitHub Actions to latest versions (#54)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,25 +20,25 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921  # stable
+        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
         with:
           toolchain: stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1  # v2.8.1
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
         with:
           workspaces: rust
 
       - name: Setup Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41  # v7.1.2
+        uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244  # v7.1.4
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -68,15 +68,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41  # v7.1.2
+        uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244  # v7.1.4
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -98,16 +98,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921  # stable
+        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
         with:
           toolchain: stable
           components: rustfmt, clippy
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1  # v2.8.1
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
         with:
           workspaces: rust
 
@@ -124,28 +124,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921  # stable
+        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
         with:
           toolchain: stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1  # v2.8.1
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
         with:
           workspaces: rust
 
       - name: Setup Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41  # v7.1.2
+        uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244  # v7.1.4
 
       - name: Cache uv dependencies
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: ~/.cache/uv
           key: ${{ runner.os }}-uv-docs-${{ hashFiles('**/pyproject.toml') }}
@@ -163,7 +163,7 @@ jobs:
         run: uv run sphinx-build -b html docs docs/_build/html
 
       - name: Upload documentation artifacts
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  # v4.5.0
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
         with:
           name: documentation
           path: docs/_build/html

--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -20,13 +20,13 @@ jobs:
         run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
 
       - name: Run issue-metrics tool
-        uses: github/issue-metrics@3cdeef0e85d5d3035e84a0e243e2e2fb3bb48d4b # v3.15.0
+        uses: github/issue-metrics@78b1d469a1b1c94945b15bd71dedcb1928667f49 # v3.25.3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: 'repo:mikelane/dioxide is:issue created:${{ steps.date.outputs.date }} -reason:"not planned"'
 
       - name: Upload metrics artifact
-        uses: actions/upload-artifact@ea165f8d65ce2e9a1a6c3f4867f37c02d33d9f4a # v4.5.0
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: issue-metrics-${{ steps.date.outputs.date }}
           path: issue_metrics.md
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Calculate SLA compliance
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -127,7 +127,7 @@ jobs:
             fs.writeFileSync('sla_report.md', slaReport);
 
       - name: Upload SLA report
-        uses: actions/upload-artifact@ea165f8d65ce2e9a1a6c3f4867f37c02d33d9f4a # v4.5.0
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: sla-compliance-report
           path: sla_report.md


### PR DESCRIPTION
## Summary

Comprehensive audit and update of all GitHub Actions across all workflows to ensure we're using the latest stable versions.

## Changes

### `.github/workflows/ci.yml` - 7 actions updated

| Action | Previous | Updated |
|--------|----------|---------|
| actions/checkout | v5.0.0 | v6.0.0 |
| actions/setup-python | v6.0.0 | v6.1.0 |
| dtolnay/rust-toolchain | stable | stable (new SHA) |
| Swatinem/rust-cache | v2.8.1 | v2.8.2 |
| astral-sh/setup-uv | v7.1.2 | v7.1.4 |
| actions/cache | v4.2.0 | v4.3.0 |
| actions/upload-artifact | v4.5.0 | v5.0.0 |

### `.github/workflows/issue-metrics.yml` - 3 actions updated

| Action | Previous | Updated |
|--------|----------|---------|
| github/issue-metrics | v3.15.0 | v3.25.3 |
| actions/upload-artifact | v4.5.0 | v5.0.0 |
| actions/checkout | v5.0.0 | v6.0.0 |

### Already Up-to-Date (No Changes)
- stale-issues.yml: actions/stale v10.1.0
- issue-triage.yml: actions/github-script v8.0.0
- auto-close-issues.yml: actions/github-script v8.0.0
- release-automated.yml: Uses version tags (@v6, @v7)

## Key Improvements

- **actions/checkout v6.0.0**: Node.js 24 support
- **astral-sh/setup-uv v7.1.4**: Critical Windows libuv bug fix
- **Swatinem/rust-cache v2.8.2**: Environment override fix
- **github/issue-metrics v3.25.3**: Multiple dependency updates

## Acceptance Criteria

- [x] All actions updated to latest stable versions
- [x] SHA pins updated to match new versions
- [x] No breaking changes in updates
- [x] All workflows still function correctly
- [x] Comprehensive documentation of what changed

Fixes #54