### PR TITLE
docs: add sphinx-tippy for rich hover previews (#215)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx_copybutton',
     'sphinx_design',
+    'sphinx_tippy',
     'sphinxcontrib.mermaid',
     'autoapi.extension',
     'myst_parser',
@@ -217,6 +218,20 @@ copybutton_prompt_is_regexp = True
 # Skip output-only blocks (lines starting with output prefixes)
 copybutton_only_copy_prompt_lines = True
 copybutton_remove_prompts = True
+
+# -- Options for sphinx-tippy extension --------------------------------------
+# Enable rich hover previews for cross-references
+# Documentation: https://sphinx-tippy.readthedocs.io/
+tippy_rtd_urls = [
+    'https://dioxide.readthedocs.io/en/latest/',
+]
+tippy_enable_mathjax = False
+tippy_props = {
+    'placement': 'auto',
+    'maxWidth': 500,
+    'interactive': True,
+    'delay': [100, 0],
+}
 
 # -- Options for sphinx-design extension -------------------------------------
 # sphinx-design provides cards, grids, tabs, dropdowns, and badges

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,7 @@ docs = [
     "sphinx-autobuild>=2024.10.3",
     "sphinx-copybutton>=0.5.2",
     "sphinx-design>=0.6.1",
+    "sphinx-tippy>=0.4.3",
     "sphinxcontrib-mermaid>=1.2.3",
 ]
 


### PR DESCRIPTION
## Summary

- Add `sphinx-tippy>=0.4.3` to docs dependency group
- Configure `sphinx_tippy` extension in docs/conf.py
- Enable hover previews with auto placement, 500px max width
- Set interactive tooltips with 100ms delay

## Test plan

- [x] Verified docs build succeeds with sphinx-tippy
- [x] Tippy data files generated for all pages

Fixes #215