### PR TITLE
feat: add container reset mechanism for testing isolation (#82)

### DIFF
--- a/python/dioxide/__init__.py
+++ b/python/dioxide/__init__.py
@@ -47,6 +47,7 @@ from .container import (
     Container,
     ScopedContainer,
     container,
+    reset_global_container,
 )
 from .exceptions import (
     AdapterNotFoundError,
@@ -76,5 +77,6 @@ __all__ = [
     'container',
     'fresh_container',
     'lifecycle',
+    'reset_global_container',
     'service',
 ]


### PR DESCRIPTION
## Summary

- Add `reset_global_container()` function for test isolation
- Export function from main package for easy access
- Include comprehensive documentation warning about testing-only usage

## Changes

### Modified Files
- `python/dioxide/container.py` - Added `reset_global_container()` function
- `python/dioxide/__init__.py` - Export the new function
- `tests/test_container_reset.py` - New test file with 6 tests

## Features

- **`reset_global_container()`** - Resets global container to empty state
- Clears active profile
- Clears lifecycle cache  
- Preserves global container reference (existing imports continue to work)
- Clear warning in docstring about testing-only usage
- Includes pytest fixture examples in documentation

## Usage

```python
import pytest
from dioxide import reset_global_container

@pytest.fixture(autouse=True)
def isolate_container():
    reset_global_container()
    yield
    reset_global_container()
```

## Test plan

- [x] All 6 new reset tests pass
- [x] Full test suite passes (291 tests)
- [x] Function exported from main package
- [x] Works correctly in test isolation scenarios

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)