### PR TITLE
docs: Polish documentation for v1.0.0 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code when working on the dioxide codebase.
 
 **Note**: The package was recently renamed from `rivet_di` to `dioxide`. All references in code, tests, and documentation have been updated to use `dioxide`.
 
-**✅ v0.1.0-beta.2 RELEASED** (Nov 23, 2025): MLP Complete! Hexagonal architecture API, lifecycle management, circular dependency detection, performance benchmarking, FastAPI integration, and comprehensive testing guide all implemented.
+**v1.0.0 STABLE**: MLP Complete! Hexagonal architecture API, lifecycle management, circular dependency detection, performance benchmarking, framework integrations (FastAPI, Flask, Celery, Click), and comprehensive testing guide all implemented.
 
 ## MLP Vision: The North Star
 
@@ -451,6 +451,11 @@ dioxide/
 │   ├── profile_enum.py      # Profile enum (PRODUCTION, TEST, etc.)
 │   ├── scope.py             # Scope enum (SINGLETON, FACTORY)
 │   ├── exceptions.py        # Custom exceptions
+│   ├── testing.py           # Test utilities (fresh_container)
+│   ├── fastapi.py           # FastAPI integration
+│   ├── flask.py             # Flask integration
+│   ├── celery.py            # Celery integration
+│   ├── click.py             # Click CLI integration
 │   └── _registry.py         # Internal registration system
 ├── rust/src/                # Private Rust implementation
 │   └── lib.rs               # PyO3 bindings and container logic

--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ pip install dioxide
 
 ## Status
 
-**✨ STABLE**: dioxide v0.1.1 is production-ready with a stable, frozen API.
+**STABLE**: dioxide v1.0.0 is production-ready with a stable, frozen API.
 
-- **Latest Release**: [v0.1.1](https://github.com/mikelane/dioxide/releases/tag/v0.1.1) (Nov 25, 2025) - Published to PyPI
+- **Latest Release**: [v1.0.0](https://github.com/mikelane/dioxide/releases/tag/v1.0.0) - Published to PyPI
 - **API Status**: Frozen - No breaking changes until v2.0
 - **Production Ready**: All MLP features complete, comprehensive test coverage, battle-tested
 
 **Migrating from alpha/beta versions?** See [MIGRATION.md](MIGRATION.md) for the complete migration guide.
 
-See [ROADMAP.md](ROADMAP.md) for post-MLP features and [Issues](https://github.com/mikelane/dioxide/issues) for current work.
+See [Issues](https://github.com/mikelane/dioxide/issues) for current work and planned enhancements.
 
 ## Why dioxide?
 
@@ -474,7 +474,7 @@ finally:
 - **Graceful rollback**: If initialization fails, already-initialized components are disposed
 - **Error resilience**: Disposal continues even if individual components fail
 
-**Status**: Fully implemented (v0.0.4-alpha).
+**Status**: Fully implemented.
 
 ## Function Injection
 
@@ -843,7 +843,7 @@ See [Django Integration Guide](docs/integrations/django.md) for complete documen
 
 ## Features
 
-### v0.1.1 ✅ STABLE (Nov 25, 2025) - MLP Production Ready
+### v1.0.0 STABLE - MLP Production Ready
 
 **Core Dependency Injection**:
 - [x] `@adapter.for_(Port, profile=...)` decorator for hexagonal architecture
@@ -890,11 +890,12 @@ See [Django Integration Guide](docs/integrations/django.md) for complete documen
 - [x] Battle-tested in real applications
 - [x] Ready for production deployment
 
-### Post-MLP Features (v0.2.0+)
-See [ROADMAP.md](ROADMAP.md) for post-MLP features:
-- Request scoping
+### Post-MLP Features (v1.1.0+)
+
+Future enhancements under consideration:
+- Request scoping for web frameworks
 - Property injection
-- Framework integrations (FastAPI, Flask, Django)
+- Django integration
 - Developer tooling (CLI, IDE plugins)
 
 ## Development
@@ -1033,13 +1034,12 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ---
 
-**✨ Production Ready**: dioxide v0.1.1 is production-ready with a stable, frozen API. All MLP (Minimum Loveable Product) features are complete, thoroughly tested, and battle-proven.
+**Production Ready**: dioxide v1.0.0 is production-ready with a stable, frozen API. All MLP (Minimum Loveable Product) features are complete, thoroughly tested, and battle-proven.
 
-**API Guarantee**: No breaking changes until v2.0. Your code written against v0.1.x will continue to work through all v0.x and v1.x releases.
+**API Guarantee**: No breaking changes until v2.0. Your code written against v1.x will continue to work through all v1.x releases.
 
 **What's Next**:
-- **v0.2.0+**: Post-MLP enhancements (request scoping, property injection, framework integrations)
-- **v1.0.0**: Stable release after ecosystem adoption and feedback
+- **v1.1.0+**: Post-MLP enhancements (request scoping, property injection, additional framework integrations)
 - **v2.0.0+**: Major enhancements based on community needs
 
-**Get Started**: **[📖 Read the Documentation](https://dioxide.readthedocs.io)** | **[📦 Install from PyPI](https://pypi.org/project/dioxide/)** | **[💻 View on GitHub](https://github.com/mikelane/dioxide)**
+**Get Started**: **[Read the Documentation](https://dioxide.readthedocs.io)** | **[Install from PyPI](https://pypi.org/project/dioxide/)** | **[View on GitHub](https://github.com/mikelane/dioxide)**

--- a/docs/MLP_VISION.md
+++ b/docs/MLP_VISION.md
@@ -1417,28 +1417,28 @@ Before calling this "loveable", we must have:
 - [x] Port-based resolution (`container.resolve(Port)`)
 - [x] Multiple adapter implementations per port
 
-### Phase 3: Lifecycle (Week 4) 🔄 IN PROGRESS
+### Phase 3: Lifecycle (Week 4) ✅ COMPLETE
 
-- [ ] `@lifecycle` decorator
-- [ ] `async def initialize()` support
-- [ ] `async def dispose()` support
-- [ ] Async context manager support (`async with container`)
-- [ ] Initialization in dependency order
-- [ ] Disposal in reverse dependency order
+- [x] `@lifecycle` decorator
+- [x] `async def initialize()` support
+- [x] `async def dispose()` support
+- [x] Async context manager support (`async with container`)
+- [x] Initialization in dependency order
+- [x] Disposal in reverse dependency order
 
-### Phase 4: Polish (Week 5)
+### Phase 4: Polish (Week 5) ✅ COMPLETE
 
-- [ ] Excellent error messages
-- [ ] FastAPI integration
-- [ ] Documentation
-- [ ] Testing guide
-- [ ] Examples
+- [x] Excellent error messages
+- [x] FastAPI integration
+- [x] Documentation
+- [x] Testing guide
+- [x] Examples
 
-### Phase 5: Performance (Week 6)
+### Phase 5: Performance (Week 6) ✅ COMPLETE
 
-- [ ] Rust optimization
-- [ ] Benchmark suite
-- [ ] Performance documentation
+- [x] Rust optimization
+- [x] Benchmark suite
+- [x] Performance documentation
 
 ---
 

--- a/python/dioxide/__init__.py
+++ b/python/dioxide/__init__.py
@@ -61,7 +61,7 @@ from .scope import Scope
 from .services import service
 from .testing import fresh_container
 
-__version__ = '0.1.0'
+__version__ = '1.0.0'
 __all__ = [
     'AdapterNotFoundError',
     'CaptiveDependencyError',


### PR DESCRIPTION
## Summary

- Update version references from v0.1.1 to v1.0.0 in README.md
- Mark all MLP phases (3-5) as COMPLETE in MLP_VISION.md
- Add Framework Integrations section listing FastAPI, Flask, Celery, Click
- Update CLAUDE.md repository structure to include new integration files
- Update `__version__` to '1.0.0' in python/dioxide/__init__.py
- Remove references to deleted ROADMAP.md and STATUS.md

## Test plan

- [x] Verified all code examples in documentation still accurate
- [x] Pre-commit hooks pass (ruff, mypy, isort)
- [x] No breaking changes to code

Fixes #257
Relates to #258, #259, #260