### PR TITLE
docs: sync auto-generated API documentation

### DIFF
--- a/docs/api/dioxide/celery/index.rst
+++ b/docs/api/dioxide/celery/index.rst
@@ -1,0 +1,218 @@
+dioxide.celery
+==============
+
+.. py:module:: dioxide.celery
+
+.. autoapi-nested-parse::
+
+   Celery integration for dioxide dependency injection.
+
+   This module provides seamless integration between dioxide's dependency injection
+   container and Celery background tasks. It enables:
+
+   - **Single function setup**: ``configure_dioxide(app, profile=...)``
+   - **Task scoping**: Automatic ``ScopedContainer`` per task execution via ``scoped_task``
+   - **Lifecycle management**: Container start/stop tied to Celery app configuration
+
+   Quick Start:
+       Set up dioxide in your Celery app::
+
+           from celery import Celery
+           from dioxide import Profile
+           from dioxide.celery import configure_dioxide, scoped_task
+
+           app = Celery('tasks')
+           configure_dioxide(app, profile=Profile.PRODUCTION)
+
+
+           @scoped_task(app)
+           def process_order(scope, order_id: str) -> dict:
+               service = scope.resolve(OrderService)
+               return service.process(order_id)
+
+
+           # Execute task
+           result = process_order.delay('order-123')
+
+   Task Scoping:
+       The integration creates a ``ScopedContainer`` for each task execution.
+       This enables REQUEST-scoped components to be fresh for each task::
+
+           from dioxide import service, Scope
+
+
+           @service(scope=Scope.REQUEST)
+           class TaskContext:
+               def __init__(self):
+                   import uuid
+
+                   self.task_id = str(uuid.uuid4())
+
+
+           # In task handlers:
+           @scoped_task(app)
+           def my_task(scope) -> str:
+               ctx = scope.resolve(TaskContext)
+               # ctx.task_id is unique per task execution
+               return ctx.task_id
+
+   Lifecycle Management:
+       The integration handles container lifecycle automatically::
+
+           from dioxide import adapter, lifecycle, Profile
+
+
+           @adapter.for_(DatabasePort, profile=Profile.PRODUCTION)
+           @lifecycle
+           class PostgresAdapter:
+               async def initialize(self) -> None:
+                   self.engine = create_engine(...)
+                   print('Database connected')
+
+               async def dispose(self) -> None:
+                   await self.engine.dispose()
+                   print('Database disconnected')
+
+
+           # When configure_dioxide is called: container.scan() and start()
+           # When task ends: scope.dispose() for REQUEST-scoped components
+
+   Thread Safety:
+       Celery uses processes/threads for task execution. The integration creates
+       a fresh scope per task execution, ensuring each task gets its own isolated
+       REQUEST-scoped dependencies. SINGLETON-scoped components are shared across
+       tasks within the same worker process.
+
+   .. seealso::
+
+      - :func:`configure_dioxide` - The main setup function
+      - :func:`scoped_task` - Decorator for task scoping
+      - :class:`dioxide.container.Container` - The DI container
+      - :class:`dioxide.container.ScopedContainer` - Task-scoped container
+
+
+
+Functions
+---------
+
+.. autoapisummary::
+
+   dioxide.celery.configure_dioxide
+   dioxide.celery.scoped_task
+
+
+Module Contents
+---------------
+
+.. py:function:: configure_dioxide(app, profile = None, container = None, packages = None)
+
+   Configure dioxide dependency injection for a Celery application.
+
+   This function sets up the integration between dioxide and Celery:
+
+   1. Scans for components in specified packages (or all registered)
+   2. Starts the container (initializing @lifecycle components)
+   3. Stores the container reference on the Celery app
+
+   :param app: The Celery application instance
+   :param profile: Profile to scan with (e.g., ``Profile.PRODUCTION``). Accepts
+                   either a Profile enum value or a string profile name.
+   :param container: Optional Container instance. If not provided, uses the
+                     global ``dioxide.container`` singleton.
+   :param packages: Optional list of packages to scan for components. If not
+                    provided, scans all registered components.
+
+   :raises ImportError: If Celery is not installed.
+
+   .. admonition:: Example
+
+      Basic setup::
+
+          from celery import Celery
+          from dioxide import Profile
+          from dioxide.celery import configure_dioxide
+
+          app = Celery('tasks')
+          configure_dioxide(app, profile=Profile.PRODUCTION)
+
+      With custom container::
+
+          from dioxide import Container, Profile
+          from dioxide.celery import configure_dioxide
+
+          my_container = Container()
+          app = Celery('tasks')
+          configure_dioxide(app, profile=Profile.TEST, container=my_container)
+
+      With package scanning::
+
+          configure_dioxide(
+              app,
+              profile=Profile.PRODUCTION,
+              packages=['myapp.services', 'myapp.adapters'],
+          )
+
+   .. seealso::
+
+      - :func:`scoped_task` - How to create scoped tasks
+      - :class:`dioxide.container.ScopedContainer` - How scoping works
+
+
+.. py:function:: scoped_task(app, **task_options)
+
+   Decorator to create a Celery task with dioxide scoping.
+
+   Creates a Celery task that automatically receives a ScopedContainer
+   as its first argument. The scope is created before task execution
+   and disposed after completion (including on errors).
+
+   :param app: The Celery application instance (must be configured with configure_dioxide)
+   :param \*\*task_options: Additional options to pass to Celery's @app.task decorator
+                            (e.g., name, bind, queue, etc.)
+
+   :returns: A decorator function that wraps the task with scoping.
+
+   .. admonition:: Example
+
+      Basic usage::
+
+          from dioxide.celery import configure_dioxide, scoped_task
+
+          app = Celery('tasks')
+          configure_dioxide(app, profile=Profile.PRODUCTION)
+
+
+          @scoped_task(app)
+          def process_order(scope, order_id: str) -> dict:
+              service = scope.resolve(OrderService)
+              return service.process(order_id)
+
+
+          # Execute task
+          result = process_order.delay('order-123')
+
+      With Celery task options::
+
+          @scoped_task(app, name='custom.task.name', queue='high-priority')
+          def important_task(scope) -> None:
+              pass
+
+      Async task::
+
+          @scoped_task(app)
+          async def async_task(scope) -> str:
+              ctx = scope.resolve(TaskContext)
+              await asyncio.sleep(0.1)
+              return ctx.task_id
+
+   .. note::
+
+      - The scope is always injected as the FIRST argument
+      - REQUEST-scoped components are fresh per task execution
+      - SINGLETON-scoped components are shared across tasks in the same worker
+      - @lifecycle components with REQUEST scope are disposed after task completion
+
+   .. seealso::
+
+      - :func:`configure_dioxide` - Must be called first
+      - :class:`dioxide.container.ScopedContainer` - How scoping works

--- a/docs/api/dioxide/click/index.rst
+++ b/docs/api/dioxide/click/index.rst
@@ -1,0 +1,272 @@
+dioxide.click
+=============
+
+.. py:module:: dioxide.click
+
+.. autoapi-nested-parse::
+
+   Click integration for dioxide dependency injection.
+
+   This module provides seamless integration between dioxide's dependency injection
+   container and Click CLI applications. It enables:
+
+   - **Single function setup**: ``configure_dioxide(profile=...)``
+   - **Command scoping**: ``@with_scope(container)`` decorator for per-command scopes
+   - **Clean injection**: Scope passed as first argument to commands
+   - **Lifecycle management**: Components disposed after command completes
+
+   Quick Start:
+       Set up dioxide in your Click CLI::
+
+           import click
+           from dioxide import Profile
+           from dioxide.click import configure_dioxide, with_scope
+
+           container = configure_dioxide(profile=Profile.PRODUCTION)
+
+
+           @click.command()
+           @with_scope(container)
+           def greet(scope, name):
+               service = scope.resolve(GreetingService)
+               click.echo(service.greet(name))
+
+
+           @click.argument('name')
+           def main():
+               greet()
+
+   Command Scoping:
+       The ``with_scope`` decorator creates a ``ScopedContainer`` for each command
+       invocation. This enables REQUEST-scoped components to be fresh for each
+       command while SINGLETON components remain shared::
+
+           from dioxide import service, Scope
+
+
+           @service(scope=Scope.REQUEST)
+           class CommandContext:
+               def __init__(self):
+                   import uuid
+
+                   self.command_id = str(uuid.uuid4())
+
+
+           @click.command()
+           @with_scope(container)
+           def my_command(scope):
+               ctx = scope.resolve(CommandContext)
+               # ctx.command_id is unique per command invocation
+               click.echo(f'Command ID: {ctx.command_id}')
+
+   Lifecycle Management:
+       The integration handles lifecycle disposal automatically::
+
+           from dioxide import adapter, lifecycle, Profile
+
+
+           @adapter.for_(DatabasePort, profile=Profile.PRODUCTION)
+           @lifecycle
+           class PostgresAdapter:
+               async def initialize(self) -> None:
+                   self.engine = create_engine(...)
+                   print('Database connected')
+
+               async def dispose(self) -> None:
+                   await self.engine.dispose()
+                   print('Database disconnected')
+
+
+           # When command completes: scope disposes REQUEST-scoped @lifecycle components
+
+   Click Groups:
+       The integration works with Click groups and nested commands::
+
+           @click.group()
+           def cli():
+               pass
+
+
+           @cli.command()
+           @with_scope(container)
+           @click.argument('user_id')
+           def get_user(scope, user_id):
+               service = scope.resolve(UserService)
+               click.echo(service.get_user(user_id))
+
+
+           @cli.group()
+           def config():
+               pass
+
+
+           @config.command()
+           @with_scope(container)
+           @click.argument('key')
+           def get(scope, key):
+               service = scope.resolve(ConfigService)
+               click.echo(service.get_value(key))
+
+   Typer Compatibility:
+       Since Typer is built on Click, this integration works with Typer applications::
+
+           import typer
+           import click
+           from dioxide.click import configure_dioxide, with_scope
+
+           container = configure_dioxide(profile=Profile.PRODUCTION)
+           app = typer.Typer()
+
+
+           @click.command()
+           @with_scope(container)
+           @click.argument('name')
+           def greet(scope, name):
+               service = scope.resolve(GreetingService)
+               typer.echo(service.greet(name))
+
+
+           app.command()(greet)
+
+   .. seealso::
+
+      - :func:`configure_dioxide` - The main setup function
+      - :func:`with_scope` - Decorator for per-command scoping
+      - :class:`dioxide.container.Container` - The DI container
+      - :class:`dioxide.container.ScopedContainer` - Command-scoped container
+
+
+
+Functions
+---------
+
+.. autoapisummary::
+
+   dioxide.click.configure_dioxide
+   dioxide.click.with_scope
+
+
+Module Contents
+---------------
+
+.. py:function:: configure_dioxide(profile = None, container = None, packages = None)
+
+   Configure dioxide dependency injection for a Click CLI application.
+
+   This function sets up the integration between dioxide and Click:
+
+   1. Creates or uses provided container
+   2. Scans for components in specified packages (or all registered)
+   3. Returns the configured container for use with ``with_scope``
+
+   :param profile: Profile to scan with (e.g., ``Profile.PRODUCTION``). Accepts
+                   either a Profile enum value or a string profile name.
+   :param container: Optional Container instance. If not provided, creates a new
+                     Container instance.
+   :param packages: Optional list of packages to scan for components. If not
+                    provided, scans all registered components.
+
+   :returns: The configured Container instance ready for use with ``with_scope``.
+
+   :raises ImportError: If Click is not installed.
+
+   .. admonition:: Example
+
+      Basic setup::
+
+          from dioxide import Profile
+          from dioxide.click import configure_dioxide
+
+          container = configure_dioxide(profile=Profile.PRODUCTION)
+
+      With custom container::
+
+          from dioxide import Container, Profile
+          from dioxide.click import configure_dioxide
+
+          my_container = Container()
+          container = configure_dioxide(profile=Profile.TEST, container=my_container)
+
+      With package scanning::
+
+          container = configure_dioxide(
+              profile=Profile.PRODUCTION,
+              packages=['myapp.services', 'myapp.adapters'],
+          )
+
+   .. seealso::
+
+      - :func:`with_scope` - How to inject dependencies in commands
+      - :class:`dioxide.container.ScopedContainer` - How scoping works
+
+
+.. py:function:: with_scope(container)
+
+   Decorator that creates a dioxide scope for each command invocation.
+
+   This decorator wraps a Click command to:
+   1. Create a new ScopedContainer before the command runs
+   2. Pass the scope as the first argument to the command
+   3. Dispose the scope after the command completes (even on error)
+
+   The scope enables REQUEST-scoped components to be cached within a single
+   command invocation while remaining fresh across different invocations.
+
+   :param container: The Container instance (from ``configure_dioxide``).
+
+   :returns: A decorator that wraps Click commands with scope management.
+
+   .. admonition:: Example
+
+      Basic usage::
+
+          from dioxide.click import configure_dioxide, with_scope
+
+          container = configure_dioxide(profile=Profile.PRODUCTION)
+
+
+          @click.command()
+          @with_scope(container)
+          def my_command(scope):
+              service = scope.resolve(MyService)
+              click.echo(service.do_something())
+
+      With Click arguments and options::
+
+          @click.command()
+          @with_scope(container)
+          @click.option('--verbose', is_flag=True)
+          @click.argument('name')
+          def greet(scope, verbose, name):
+              service = scope.resolve(GreetingService)
+              result = service.greet(name)
+              if verbose:
+                  click.echo(f'Greeting: {result}')
+              else:
+                  click.echo(result)
+
+      With Click groups::
+
+          @click.group()
+          def cli():
+              pass
+
+
+          @cli.command()
+          @with_scope(container)
+          @click.argument('user_id')
+          def get_user(scope, user_id):
+              service = scope.resolve(UserService)
+              click.echo(service.get_user(user_id))
+
+   .. note::
+
+      The scope is always passed as the FIRST argument to the decorated
+      function, before any Click arguments or options. This is because
+      decorators are applied bottom-up, and ``with_scope`` needs to inject
+      the scope before Click processes its arguments.
+
+   .. seealso::
+
+      - :func:`configure_dioxide` - Must be called first to get container
+      - :class:`dioxide.container.ScopedContainer` - How scoping works

--- a/docs/api/dioxide/django/index.rst
+++ b/docs/api/dioxide/django/index.rst
@@ -1,0 +1,303 @@
+dioxide.django
+==============
+
+.. py:module:: dioxide.django
+
+.. autoapi-nested-parse::
+
+   Django integration for dioxide dependency injection.
+
+   This module provides seamless integration between dioxide's dependency injection
+   container and Django applications. It enables:
+
+   - **Single function setup**: ``configure_dioxide(profile=...)``
+   - **Request scoping**: Automatic ``ScopedContainer`` per HTTP request via middleware
+   - **Clean injection**: ``inject(Type)`` resolves from current request scope
+   - **Lifecycle management**: Container start/stop tied to Django configuration
+
+   Quick Start:
+       Set up dioxide in your Django settings.py or apps.py::
+
+           # In settings.py or your AppConfig.ready()
+           from dioxide import Profile
+           from dioxide.django import configure_dioxide
+
+           configure_dioxide(profile=Profile.PRODUCTION)
+
+       Add the middleware to settings.py::
+
+           MIDDLEWARE = [
+               ...
+               'dioxide.django.DioxideMiddleware',
+               ...
+           ]
+
+       Use in views::
+
+           from dioxide.django import inject
+
+
+           def my_view(request):
+               service = inject(UserService)
+               return JsonResponse(service.get_data())
+
+   Request Scoping:
+       The middleware creates a ``ScopedContainer`` for each HTTP request.
+       This enables REQUEST-scoped components to be shared within a single
+       request but fresh for each new request::
+
+           from dioxide import service, Scope
+
+
+           @service(scope=Scope.REQUEST)
+           class RequestContext:
+               def __init__(self):
+                   import uuid
+
+                   self.request_id = str(uuid.uuid4())
+
+
+           # In views:
+           def my_view(request):
+               ctx = inject(RequestContext)
+               # ctx.request_id is unique per request
+               # but shared if resolved multiple times within same request
+               return JsonResponse({'request_id': ctx.request_id})
+
+   Lifecycle Management:
+       The integration handles container lifecycle automatically::
+
+           from dioxide import adapter, lifecycle, Profile
+
+
+           @adapter.for_(DatabasePort, profile=Profile.PRODUCTION)
+           @lifecycle
+           class PostgresAdapter:
+               async def initialize(self) -> None:
+                   self.engine = create_engine(...)
+                   print('Database connected')
+
+               async def dispose(self) -> None:
+                   await self.engine.dispose()
+                   print('Database disconnected')
+
+
+           # When configure_dioxide is called: container.scan() and start()
+           # When request ends: scope.dispose() for REQUEST-scoped components
+
+   Thread Safety:
+       Django uses threading by default. The integration stores the scoped container
+       in thread-local storage, ensuring each request gets its own scope even in
+       threaded mode.
+
+   .. seealso::
+
+      - :func:`configure_dioxide` - The main setup function
+      - :class:`DioxideMiddleware` - Request scoping middleware
+      - :func:`inject` - Dependency injection helper for views
+      - :class:`dioxide.container.Container` - The DI container
+      - :class:`dioxide.container.ScopedContainer` - Request-scoped container
+
+
+
+Classes
+-------
+
+.. autoapisummary::
+
+   dioxide.django.DioxideMiddleware
+
+
+Functions
+---------
+
+.. autoapisummary::
+
+   dioxide.django.configure_dioxide
+   dioxide.django.inject
+
+
+Module Contents
+---------------
+
+.. py:function:: configure_dioxide(profile = None, container = None, packages = None)
+
+   Configure dioxide dependency injection for a Django application.
+
+   This function sets up the integration between dioxide and Django:
+
+   1. Scans for components in specified packages (or all registered)
+   2. Starts the container (initializing @lifecycle components)
+   3. Stores the container reference for later access by middleware
+
+   Call this in your Django settings.py, apps.py ready(), or conftest.py.
+
+   :param profile: Profile to scan with (e.g., ``Profile.PRODUCTION``). Accepts
+                   either a Profile enum value or a string profile name.
+   :param container: Optional Container instance. If not provided, uses the
+                     global ``dioxide.container`` singleton.
+   :param packages: Optional list of packages to scan for components. If not
+                    provided, scans all registered components.
+
+   :raises ImportError: If Django is not installed.
+
+   .. admonition:: Example
+
+      Basic setup in settings.py::
+
+          from dioxide import Profile
+          from dioxide.django import configure_dioxide
+
+          configure_dioxide(profile=Profile.PRODUCTION)
+
+      In apps.py ready() method::
+
+          from django.apps import AppConfig
+          from dioxide import Profile
+          from dioxide.django import configure_dioxide
+
+
+          class MyAppConfig(AppConfig):
+              name = 'myapp'
+
+              def ready(self):
+                  configure_dioxide(profile=Profile.PRODUCTION)
+
+      With custom container::
+
+          from dioxide import Container, Profile
+          from dioxide.django import configure_dioxide
+
+          my_container = Container()
+          configure_dioxide(profile=Profile.TEST, container=my_container)
+
+      With package scanning::
+
+          configure_dioxide(
+              profile=Profile.PRODUCTION,
+              packages=['myapp.services', 'myapp.adapters'],
+          )
+
+   .. seealso::
+
+      - :class:`DioxideMiddleware` - Must be added to MIDDLEWARE
+      - :func:`inject` - How to inject dependencies in views
+      - :class:`dioxide.container.ScopedContainer` - How scoping works
+
+
+.. py:class:: DioxideMiddleware(get_response)
+
+   Django middleware that creates a ScopedContainer per request.
+
+   This middleware handles request scoping for dioxide:
+
+   1. Creates a ``ScopedContainer`` before the view runs
+   2. Stores it in thread-local storage for ``inject()`` to access
+   3. Disposes the scope after the response is returned
+
+   Usage in settings.py::
+
+       MIDDLEWARE = [
+           ...
+           'dioxide.django.DioxideMiddleware',
+           ...
+       ]
+
+   .. note::
+
+      The middleware must be placed after any middleware that might need
+      dioxide services, as it creates the scope on request entry.
+
+   .. seealso::
+
+      - :func:`configure_dioxide` - Must be called first
+      - :func:`inject` - How to inject dependencies in views
+      - :class:`dioxide.container.ScopedContainer` - The scoped container
+
+
+   .. py:attribute:: get_response
+
+
+   .. py:method:: __call__(request)
+
+      Process a request with dioxide scoping.
+
+      Creates a scoped container for the request, stores it in thread-local
+      storage, calls the view, and ensures cleanup on completion.
+
+      :param request: The Django HttpRequest object.
+
+      :returns: The HttpResponse from the view.
+
+
+
+.. py:function:: inject(component_type)
+
+   Resolve a component from the current request's dioxide scope.
+
+   This function retrieves a dependency from the dioxide container for
+   the current request. It automatically uses the correct scope:
+
+   - **SINGLETON**: Resolved from parent container (shared)
+   - **REQUEST**: Resolved from request scope (fresh per request)
+   - **FACTORY**: New instance each resolution
+
+   :param component_type: The type to resolve from the container
+
+   :returns: An instance of the requested type
+
+   :raises RuntimeError: If called outside a request context
+   :raises RuntimeError: If called without ``configure_dioxide()`` being set up
+   :raises ImportError: If Django is not installed
+
+   .. admonition:: Example
+
+      Basic usage::
+
+          from dioxide.django import inject
+
+
+          def my_view(request):
+              service = inject(UserService)
+              return JsonResponse(service.get_data())
+
+      Multiple dependencies::
+
+          def dashboard_view(request):
+              users = inject(UserService)
+              analytics = inject(AnalyticsService)
+              return JsonResponse(
+                  {
+                      'users': users.count(),
+                      'visits': analytics.total_visits(),
+                  }
+              )
+
+      Request-scoped dependencies::
+
+          from dioxide import service, Scope
+
+
+          @service(scope=Scope.REQUEST)
+          class RequestContext:
+              def __init__(self):
+                  self.request_id = str(uuid.uuid4())
+
+
+          def my_view(request):
+              ctx = inject(RequestContext)
+              # ctx is unique per request
+              return JsonResponse({'request_id': ctx.request_id})
+
+   .. note::
+
+      Unlike FastAPI's ``Inject()`` which returns a Depends wrapper,
+      Django's ``inject()`` directly returns the resolved instance.
+      This is because Django doesn't have a dependency injection system
+      like FastAPI's Depends.
+
+   .. seealso::
+
+      - :func:`configure_dioxide` - Must be called first
+      - :class:`DioxideMiddleware` - Must be added to MIDDLEWARE
+      - :class:`dioxide.container.ScopedContainer` - How scoping works

--- a/docs/api/dioxide/exceptions/index.rst
+++ b/docs/api/dioxide/exceptions/index.rst
@@ -184,6 +184,8 @@ Exceptions
 
    dioxide.exceptions.AdapterNotFoundError
    dioxide.exceptions.ServiceNotFoundError
+   dioxide.exceptions.ScopeError
+   dioxide.exceptions.CaptiveDependencyError
    dioxide.exceptions.CircularDependencyError
 
 
@@ -513,6 +515,226 @@ Module Contents
       - :class:`dioxide.container.Container.scan` - Auto-discovery and registration
       - :class:`dioxide.container.Container.resolve` - Where this is raised
       - :class:`AdapterNotFoundError` - For port resolution errors
+
+
+.. py:exception:: ScopeError
+
+   Bases: :py:obj:`Exception`
+
+
+   Raised when scope-related operations fail.
+
+   This error occurs when:
+   1. Attempting to resolve a REQUEST-scoped component outside of a scope context
+   2. Attempting to create nested scopes (not supported in v0.3.0)
+   3. Other scope lifecycle violations
+
+   REQUEST-scoped components require an active scope created via
+   ``container.create_scope()``. Attempting to resolve them from the parent
+   container or outside any scope context will raise this error.
+
+   The error message includes:
+       - **Component type**: Which component couldn't be resolved
+       - **Scope requirement**: Why a scope is needed
+       - **Fix hint**: How to create a scope context
+
+   When This Occurs:
+       - ``container.resolve(RequestScopedType)`` - REQUEST component outside scope
+       - ``scope.create_scope()`` - Nested scope attempt (not supported)
+       - Other scope lifecycle violations
+
+   Common Causes:
+       1. **No scope context**: Resolving REQUEST component from parent container
+       2. **Scope not started**: Scope context manager not entered
+       3. **Nested scope**: Trying to create scope within another scope
+
+   .. admonition:: Examples
+
+      REQUEST component outside scope::
+
+          from dioxide import service, Scope, Container
+
+
+          @service(scope=Scope.REQUEST)
+          class RequestContext:
+              pass
+
+
+          container = Container()
+          container.scan()
+
+          try:
+              container.resolve(RequestContext)  # No scope!
+          except ScopeError as e:
+              print(e)
+              # Output:
+              # Cannot resolve RequestContext: REQUEST-scoped components require an active scope.
+              #
+              # Hint: Use container.create_scope() to create a scope context:
+              #   async with container.create_scope() as scope:
+              #       ctx = scope.resolve(RequestContext)
+
+
+          # Solution: Create a scope
+          async with container.create_scope() as scope:
+              ctx = scope.resolve(RequestContext)  # Works!
+
+      Nested scope attempt::
+
+          async with container.create_scope() as outer:
+              try:
+                  async with outer.create_scope() as inner:  # Nested!
+                      pass
+              except ScopeError as e:
+                  print(e)
+                  # Output:
+                  # Nested scopes are not supported in v0.3.0
+
+   Best Practices:
+       - **Create scope at entry points**: Web request handlers, CLI commands, background tasks
+       - **Pass scope to dependencies**: Or let container inject scoped dependencies
+       - **One scope per request**: Don't nest scopes; use one scope per logical request
+       - **Use async context manager**: ``async with container.create_scope() as scope:``
+
+   .. seealso::
+
+      - :class:`dioxide.container.Container.create_scope` - How to create scopes
+      - :class:`dioxide.container.ScopedContainer` - The scoped container type
+      - :class:`dioxide.scope.Scope` - Scope enum including REQUEST
+
+
+.. py:exception:: CaptiveDependencyError
+
+   Bases: :py:obj:`Exception`
+
+
+   Raised when a longer-lived scope depends on a shorter-lived scope.
+
+   This error occurs during ``container.scan()`` when a SINGLETON component
+   depends on a REQUEST-scoped component. This is called a "captive dependency"
+   because the REQUEST component would be "captured" by the SINGLETON and never
+   refreshed, defeating the purpose of request scoping.
+
+   The problem with captive dependencies:
+       - SINGLETON lives for the container's lifetime
+       - REQUEST should be fresh for each scope
+       - If SINGLETON holds REQUEST, the same REQUEST instance is reused forever
+       - This violates the REQUEST scope contract and causes subtle bugs
+
+   The error message includes:
+       - **Parent component**: The SINGLETON that incorrectly depends on REQUEST
+       - **Child component**: The REQUEST-scoped dependency
+       - **Explanation**: Why this combination is invalid
+       - **Fix suggestions**: How to restructure the dependencies
+
+   When This Occurs:
+       - ``container.scan()`` - During dependency graph validation
+       - Early detection prevents runtime issues
+
+   Common Causes:
+       1. **SINGLETON depends on REQUEST**: Most common case
+       2. **Scope mismatch**: Accidentally used wrong scope on decorator
+       3. **Transitive dependency**: SINGLETON -> SERVICE -> REQUEST
+
+   Valid Scope Dependencies:
+       - SINGLETON -> SINGLETON (OK: same lifetime)
+       - SINGLETON -> FACTORY (OK: creates new instance)
+       - REQUEST -> SINGLETON (OK: shorter uses longer)
+       - REQUEST -> REQUEST (OK: same scope)
+       - REQUEST -> FACTORY (OK: creates new instance)
+       - FACTORY -> any (OK: always creates new)
+
+   Invalid Scope Dependencies:
+       - SINGLETON -> REQUEST (INVALID: captive dependency)
+
+   .. admonition:: Examples
+
+      Captive dependency detected at scan time::
+
+          from dioxide import service, Scope, Container
+
+
+          @service(scope=Scope.REQUEST)
+          class RequestContext:
+              def __init__(self):
+                  self.request_id = '...'
+
+
+          @service  # SINGLETON (default)
+          class GlobalService:
+              def __init__(self, ctx: RequestContext):  # BAD: SINGLETON -> REQUEST
+                  self.ctx = ctx
+
+
+          container = Container()
+
+          try:
+              container.scan()
+          except CaptiveDependencyError as e:
+              print(e)
+              # Output:
+              # Captive dependency detected: GlobalService (SINGLETON) depends on
+              # RequestContext (REQUEST).
+              #
+              # SINGLETON components cannot depend on REQUEST-scoped components because
+              # the REQUEST instance would be captured and never refreshed.
+              #
+              # Solutions:
+              # 1. Change GlobalService to REQUEST scope:
+              #    @service(scope=Scope.REQUEST)
+              # 2. Change RequestContext to SINGLETON scope (if appropriate)
+              # 3. Use a factory/provider pattern to get fresh instances
+
+      Valid dependency structure::
+
+          @service(scope=Scope.SINGLETON)
+          class AppConfig:
+              pass
+
+
+          @service(scope=Scope.REQUEST)
+          class RequestHandler:
+              def __init__(self, config: AppConfig):  # OK: REQUEST -> SINGLETON
+                  self.config = config
+
+   Solutions:
+       1. **Change parent scope**::
+
+           # Make the parent REQUEST-scoped too
+           @service(scope=Scope.REQUEST)
+           class RequestService:
+               def __init__(self, ctx: RequestContext):
+                   self.ctx = ctx
+
+       2. **Change child scope** (if appropriate)::
+
+           # If the child doesn't truly need request scope
+           @service  # SINGLETON
+           class SharedContext:
+               pass
+
+       3. **Use factory/provider pattern**::
+
+           @service  # SINGLETON
+           class GlobalService:
+               def __init__(self, container: Container):
+                   self.container = container
+
+               def get_context(self) -> RequestContext:
+                   # Get fresh instance from current scope
+                   return current_scope.resolve(RequestContext)
+
+   Best Practices:
+       - **Review scope assignments**: Ensure scopes match component lifetimes
+       - **Fail fast**: Error at scan() time prevents runtime surprises
+       - **Draw dependency graph**: Visualize scope relationships
+       - **Default to REQUEST**: For components that vary per-request
+
+   .. seealso::
+
+      - :class:`dioxide.scope.Scope` - Scope enum (SINGLETON, REQUEST, FACTORY)
+      - :class:`dioxide.container.Container.scan` - Where this error is raised
+      - :class:`ScopeError` - For runtime scope errors
 
 
 .. py:exception:: CircularDependencyError

--- a/docs/api/dioxide/fastapi/index.rst
+++ b/docs/api/dioxide/fastapi/index.rst
@@ -1,0 +1,265 @@
+dioxide.fastapi
+===============
+
+.. py:module:: dioxide.fastapi
+
+.. autoapi-nested-parse::
+
+   FastAPI integration for dioxide dependency injection.
+
+   This module provides seamless integration between dioxide's dependency injection
+   container and FastAPI applications. It enables:
+
+   - **Single middleware setup**: ``app.add_middleware(DioxideMiddleware, profile=...)``
+   - **Request scoping**: Automatic ``ScopedContainer`` per HTTP request
+   - **Clean injection**: ``Inject(Type)`` wrapper for FastAPI's ``Depends()``
+   - **Lifecycle management**: Container start/stop with FastAPI lifespan
+
+   Quick Start:
+       Set up dioxide in your FastAPI app::
+
+           from fastapi import FastAPI
+           from dioxide import Profile
+           from dioxide.fastapi import DioxideMiddleware, Inject
+
+           app = FastAPI()
+           app.add_middleware(DioxideMiddleware, profile=Profile.PRODUCTION)
+
+
+           @app.get('/users/me')
+           async def get_me(ctx: RequestContext = Inject(RequestContext)):
+               return {'request_id': str(ctx.request_id)}
+
+
+           @app.get('/users')
+           async def list_users(service: UserService = Inject(UserService)):
+               return await service.list_all()
+
+   Request Scoping:
+       The middleware creates a ``ScopedContainer`` for each HTTP request.
+       This enables REQUEST-scoped components to be shared within a single
+       request but fresh for each new request::
+
+           from dioxide import service, Scope
+
+
+           @service(scope=Scope.REQUEST)
+           class RequestContext:
+               def __init__(self):
+                   import uuid
+
+                   self.request_id = str(uuid.uuid4())
+
+
+           # In route handlers:
+           @app.get('/test')
+           async def test(ctx: RequestContext = Inject(RequestContext)):
+               # ctx.request_id is unique per request
+               # but shared if resolved multiple times within same request
+               return {'request_id': ctx.request_id}
+
+   Lifecycle Management:
+       The middleware handles container lifecycle automatically::
+
+           from dioxide import adapter, lifecycle, Profile
+
+
+           @adapter.for_(DatabasePort, profile=Profile.PRODUCTION)
+           @lifecycle
+           class PostgresAdapter:
+               async def initialize(self) -> None:
+                   self.engine = create_engine(...)
+                   print('Database connected')
+
+               async def dispose(self) -> None:
+                   await self.engine.dispose()
+                   print('Database disconnected')
+
+
+           # When FastAPI starts: container.start() initializes adapters
+           # When FastAPI stops: container.stop() disposes adapters
+
+   .. seealso::
+
+      - :class:`DioxideMiddleware` - The main integration middleware
+      - :func:`Inject` - Dependency injection helper for route handlers
+      - :class:`dioxide.container.Container` - The DI container
+      - :class:`dioxide.container.ScopedContainer` - Request-scoped container
+
+
+
+Classes
+-------
+
+.. autoapisummary::
+
+   dioxide.fastapi.DioxideMiddleware
+
+
+Functions
+---------
+
+.. autoapisummary::
+
+   dioxide.fastapi.Inject
+
+
+Module Contents
+---------------
+
+.. py:class:: DioxideMiddleware(app, profile = None, container = None, packages = None)
+
+   ASGI middleware that integrates dioxide with FastAPI.
+
+   This middleware handles both:
+
+   1. **Lifecycle management**: Container ``start()``/``stop()`` via ASGI lifespan
+   2. **Request scoping**: Creates ``ScopedContainer`` per HTTP request
+
+   The middleware intercepts ASGI events:
+
+   - ``lifespan``: Scans components and starts/stops the container
+   - ``http``: Creates a scoped container for each request
+
+   Usage:
+       Basic setup with profile::
+
+           from fastapi import FastAPI
+           from dioxide import Profile
+           from dioxide.fastapi import DioxideMiddleware
+
+           app = FastAPI()
+           app.add_middleware(DioxideMiddleware, profile=Profile.PRODUCTION)
+
+       With custom container::
+
+           from dioxide import Container, Profile
+           from dioxide.fastapi import DioxideMiddleware
+
+           my_container = Container()
+           app = FastAPI()
+           app.add_middleware(
+               DioxideMiddleware,
+               container=my_container,
+               profile=Profile.TEST,
+           )
+
+       With package scanning::
+
+           app.add_middleware(
+               DioxideMiddleware,
+               profile=Profile.PRODUCTION,
+               packages=['myapp.services', 'myapp.adapters'],
+           )
+
+   :param app: The ASGI application to wrap
+   :param profile: Profile to scan with (e.g., ``Profile.PRODUCTION``)
+   :param container: Optional Container instance. If not provided, uses
+                     the global ``dioxide.container`` singleton.
+   :param packages: Optional list of packages to scan for components.
+
+   .. seealso::
+
+      - :func:`Inject` - How to inject dependencies in routes
+      - :class:`dioxide.container.ScopedContainer` - The scoped container
+
+
+   .. py:attribute:: app
+
+
+   .. py:attribute:: profile
+      :value: None
+
+
+
+   .. py:attribute:: container
+
+
+   .. py:attribute:: packages
+      :value: None
+
+
+
+   .. py:method:: __call__(scope, receive, send)
+      :async:
+
+
+      Process an ASGI request.
+
+      Handles three ASGI scope types:
+
+      - ``lifespan``: Manages container startup/shutdown
+      - ``http``: Creates ScopedContainer per request
+      - Other types: Passes through unchanged
+
+      :param scope: ASGI scope dictionary
+      :param receive: ASGI receive callable
+      :param send: ASGI send callable
+
+
+
+.. py:function:: Inject(component_type)
+
+   Create a FastAPI dependency that resolves from dioxide container.
+
+   This function wraps FastAPI's ``Depends()`` to resolve dependencies
+   from the dioxide container. It automatically uses the correct scope:
+
+   - **SINGLETON**: Resolved from parent container (shared)
+   - **REQUEST**: Resolved from request scope (fresh per request)
+   - **FACTORY**: New instance each resolution
+
+   :param component_type: The type to resolve from the container
+
+   :returns: A FastAPI ``Depends()`` object that resolves the component
+
+   .. admonition:: Example
+
+      Basic usage::
+
+          from dioxide.fastapi import Inject
+
+
+          @app.get('/users')
+          async def list_users(service: UserService = Inject(UserService)):
+              return await service.list_all()
+
+      Multiple dependencies::
+
+          @app.get('/dashboard')
+          async def dashboard(
+              users: UserService = Inject(UserService),
+              analytics: AnalyticsService = Inject(AnalyticsService),
+          ):
+              return {
+                  'users': await users.count(),
+                  'visits': await analytics.total_visits(),
+              }
+
+      Request-scoped dependencies::
+
+          from dioxide import service, Scope
+
+
+          @service(scope=Scope.REQUEST)
+          class RequestContext:
+              def __init__(self):
+                  self.request_id = str(uuid.uuid4())
+
+
+          @app.get('/test')
+          async def test(ctx: RequestContext = Inject(RequestContext)):
+              # ctx is unique per request
+              return {'request_id': ctx.request_id}
+
+   :raises RuntimeError: If called without ``DioxideMiddleware`` being configured
+
+   .. note::
+
+      The function name is capitalized (``Inject``) to match the convention
+      of FastAPI's ``Depends``, ``Query``, ``Body``, etc.
+
+   .. seealso::
+
+      - :class:`DioxideMiddleware` - Must be added first
+      - :class:`dioxide.container.ScopedContainer` - How scoping works

--- a/docs/api/dioxide/flask/index.rst
+++ b/docs/api/dioxide/flask/index.rst
@@ -1,0 +1,242 @@
+dioxide.flask
+=============
+
+.. py:module:: dioxide.flask
+
+.. autoapi-nested-parse::
+
+   Flask integration for dioxide dependency injection.
+
+   This module provides seamless integration between dioxide's dependency injection
+   container and Flask applications. It enables:
+
+   - **Single function setup**: ``configure_dioxide(app, profile=...)``
+   - **Request scoping**: Automatic ``ScopedContainer`` per HTTP request via Flask's ``g``
+   - **Clean injection**: ``inject(Type)`` resolves from current request scope
+   - **Lifecycle management**: Container start/stop tied to Flask app configuration
+
+   Quick Start:
+       Set up dioxide in your Flask app::
+
+           from flask import Flask
+           from dioxide import Profile
+           from dioxide.flask import configure_dioxide, inject
+
+           app = Flask(__name__)
+           configure_dioxide(app, profile=Profile.PRODUCTION)
+
+
+           @app.route('/users/me')
+           def get_me():
+               ctx = inject(RequestContext)
+               return {'request_id': str(ctx.request_id)}
+
+
+           @app.route('/users')
+           def list_users():
+               service = inject(UserService)
+               return service.list_all()
+
+   Request Scoping:
+       The integration creates a ``ScopedContainer`` for each HTTP request.
+       This enables REQUEST-scoped components to be shared within a single
+       request but fresh for each new request::
+
+           from dioxide import service, Scope
+
+
+           @service(scope=Scope.REQUEST)
+           class RequestContext:
+               def __init__(self):
+                   import uuid
+
+                   self.request_id = str(uuid.uuid4())
+
+
+           # In route handlers:
+           @app.route('/test')
+           def test():
+               ctx = inject(RequestContext)
+               # ctx.request_id is unique per request
+               # but shared if resolved multiple times within same request
+               return {'request_id': ctx.request_id}
+
+   Lifecycle Management:
+       The integration handles container lifecycle automatically::
+
+           from dioxide import adapter, lifecycle, Profile
+
+
+           @adapter.for_(DatabasePort, profile=Profile.PRODUCTION)
+           @lifecycle
+           class PostgresAdapter:
+               async def initialize(self) -> None:
+                   self.engine = create_engine(...)
+                   print('Database connected')
+
+               async def dispose(self) -> None:
+                   await self.engine.dispose()
+                   print('Database disconnected')
+
+
+           # When configure_dioxide is called: container.scan() and start()
+           # When request ends: scope.dispose() for REQUEST-scoped components
+
+   Thread Safety:
+       Flask uses threading by default. The integration stores the scoped container
+       in Flask's ``g`` object, which is thread-local, ensuring each request gets
+       its own scope even in threaded mode.
+
+   .. seealso::
+
+      - :func:`configure_dioxide` - The main setup function
+      - :func:`inject` - Dependency injection helper for route handlers
+      - :class:`dioxide.container.Container` - The DI container
+      - :class:`dioxide.container.ScopedContainer` - Request-scoped container
+
+
+
+Functions
+---------
+
+.. autoapisummary::
+
+   dioxide.flask.configure_dioxide
+   dioxide.flask.inject
+
+
+Module Contents
+---------------
+
+.. py:function:: configure_dioxide(app, profile = None, container = None, packages = None)
+
+   Configure dioxide dependency injection for a Flask application.
+
+   This function sets up the integration between dioxide and Flask:
+
+   1. Scans for components in specified packages (or all registered)
+   2. Starts the container (initializing @lifecycle components)
+   3. Registers request hooks for per-request scoping
+   4. Stores the container in app.config for later access
+
+   :param app: The Flask application instance
+   :param profile: Profile to scan with (e.g., ``Profile.PRODUCTION``). Accepts
+                   either a Profile enum value or a string profile name.
+   :param container: Optional Container instance. If not provided, uses the
+                     global ``dioxide.container`` singleton.
+   :param packages: Optional list of packages to scan for components. If not
+                    provided, scans all registered components.
+
+   :raises ImportError: If Flask is not installed.
+
+   .. admonition:: Example
+
+      Basic setup::
+
+          from flask import Flask
+          from dioxide import Profile
+          from dioxide.flask import configure_dioxide
+
+          app = Flask(__name__)
+          configure_dioxide(app, profile=Profile.PRODUCTION)
+
+      With custom container::
+
+          from dioxide import Container, Profile
+          from dioxide.flask import configure_dioxide
+
+          my_container = Container()
+          app = Flask(__name__)
+          configure_dioxide(app, profile=Profile.TEST, container=my_container)
+
+      With package scanning::
+
+          configure_dioxide(
+              app,
+              profile=Profile.PRODUCTION,
+              packages=['myapp.services', 'myapp.adapters'],
+          )
+
+      App factory pattern::
+
+          def create_app():
+              app = Flask(__name__)
+              configure_dioxide(app, profile=Profile.PRODUCTION)
+              return app
+
+   .. seealso::
+
+      - :func:`inject` - How to inject dependencies in routes
+      - :class:`dioxide.container.ScopedContainer` - How scoping works
+
+
+.. py:function:: inject(component_type)
+
+   Resolve a component from the current request's dioxide scope.
+
+   This function retrieves a dependency from the dioxide container for
+   the current request. It automatically uses the correct scope:
+
+   - **SINGLETON**: Resolved from parent container (shared)
+   - **REQUEST**: Resolved from request scope (fresh per request)
+   - **FACTORY**: New instance each resolution
+
+   :param component_type: The type to resolve from the container
+
+   :returns: An instance of the requested type
+
+   :raises RuntimeError: If called outside a request context
+   :raises RuntimeError: If called without ``configure_dioxide()`` being set up
+   :raises ImportError: If Flask is not installed
+
+   .. admonition:: Example
+
+      Basic usage::
+
+          from dioxide.flask import inject
+
+
+          @app.route('/users')
+          def list_users():
+              service = inject(UserService)
+              return service.list_all()
+
+      Multiple dependencies::
+
+          @app.route('/dashboard')
+          def dashboard():
+              users = inject(UserService)
+              analytics = inject(AnalyticsService)
+              return {
+                  'users': users.count(),
+                  'visits': analytics.total_visits(),
+              }
+
+      Request-scoped dependencies::
+
+          from dioxide import service, Scope
+
+
+          @service(scope=Scope.REQUEST)
+          class RequestContext:
+              def __init__(self):
+                  self.request_id = str(uuid.uuid4())
+
+
+          @app.route('/test')
+          def test():
+              ctx = inject(RequestContext)
+              # ctx is unique per request
+              return {'request_id': ctx.request_id}
+
+   .. note::
+
+      Unlike FastAPI's ``Inject()`` which returns a Depends wrapper,
+      Flask's ``inject()`` directly returns the resolved instance.
+      This is because Flask doesn't have a dependency injection system
+      like FastAPI's Depends.
+
+   .. seealso::
+
+      - :func:`configure_dioxide` - Must be called first
+      - :class:`dioxide.container.ScopedContainer` - How scoping works

--- a/docs/api/dioxide/ninja/index.rst
+++ b/docs/api/dioxide/ninja/index.rst
@@ -1,0 +1,315 @@
+dioxide.ninja
+=============
+
+.. py:module:: dioxide.ninja
+
+.. autoapi-nested-parse::
+
+   Django Ninja integration for dioxide dependency injection.
+
+   This module provides seamless integration between dioxide's dependency injection
+   container and Django Ninja applications. It enables:
+
+   - **Single function setup**: ``configure_dioxide(api, profile=...)``
+   - **Request scoping**: Automatic ``ScopedContainer`` per HTTP request via middleware
+   - **Clean injection**: ``inject(Type)`` resolves from current request scope
+   - **Lifecycle management**: Container start/stop tied to Django configuration
+
+   Quick Start:
+       Set up dioxide in your Django Ninja app::
+
+           from ninja import NinjaAPI
+           from dioxide import Profile
+           from dioxide.ninja import configure_dioxide, inject
+
+           api = NinjaAPI()
+           configure_dioxide(api, profile=Profile.PRODUCTION)
+
+
+           @api.get('/users/me')
+           def get_me(request):
+               ctx = inject(RequestContext)
+               return {'request_id': str(ctx.request_id)}
+
+
+           @api.get('/users')
+           def list_users(request):
+               service = inject(UserService)
+               return service.list_all()
+
+       Add the middleware to your Django settings::
+
+           MIDDLEWARE = [
+               ...
+               'dioxide.ninja.DioxideMiddleware',
+               ...
+           ]
+
+   Request Scoping:
+       The middleware creates a ``ScopedContainer`` for each HTTP request.
+       This enables REQUEST-scoped components to be shared within a single
+       request but fresh for each new request::
+
+           from dioxide import service, Scope
+
+
+           @service(scope=Scope.REQUEST)
+           class RequestContext:
+               def __init__(self):
+                   import uuid
+
+                   self.request_id = str(uuid.uuid4())
+
+
+           # In route handlers:
+           @api.get('/test')
+           def test(request):
+               ctx = inject(RequestContext)
+               # ctx.request_id is unique per request
+               # but shared if resolved multiple times within same request
+               return {'request_id': ctx.request_id}
+
+   Lifecycle Management:
+       The integration handles container lifecycle automatically::
+
+           from dioxide import adapter, lifecycle, Profile
+
+
+           @adapter.for_(DatabasePort, profile=Profile.PRODUCTION)
+           @lifecycle
+           class PostgresAdapter:
+               async def initialize(self) -> None:
+                   self.engine = create_engine(...)
+                   print('Database connected')
+
+               async def dispose(self) -> None:
+                   await self.engine.dispose()
+                   print('Database disconnected')
+
+
+           # When configure_dioxide is called: container.scan() and start()
+           # When request ends: scope.dispose() for REQUEST-scoped components
+
+   Thread Safety:
+       Django uses threading by default. The integration stores the scoped container
+       in thread-local storage, ensuring each request gets its own scope even in
+       threaded mode.
+
+   .. note::
+
+      Unlike FastAPI which has built-in dependency injection via ``Depends()``,
+      Django Ninja uses Django's request handling model. This integration follows
+      the same pattern as ``dioxide.django``, using middleware for request scoping
+      and ``inject()`` for resolving dependencies inside route handlers.
+
+   .. seealso::
+
+      - :func:`configure_dioxide` - The main setup function
+      - :class:`DioxideMiddleware` - Request scoping middleware
+      - :func:`inject` - Dependency injection helper for route handlers
+      - :class:`dioxide.container.Container` - The DI container
+      - :class:`dioxide.container.ScopedContainer` - Request-scoped container
+
+
+
+Classes
+-------
+
+.. autoapisummary::
+
+   dioxide.ninja.DioxideMiddleware
+
+
+Functions
+---------
+
+.. autoapisummary::
+
+   dioxide.ninja.configure_dioxide
+   dioxide.ninja.inject
+
+
+Module Contents
+---------------
+
+.. py:function:: configure_dioxide(api, profile = None, container = None, packages = None)
+
+   Configure dioxide dependency injection for a Django Ninja application.
+
+   This function sets up the integration between dioxide and Django Ninja:
+
+   1. Scans for components in specified packages (or all registered)
+   2. Starts the container (initializing @lifecycle components)
+   3. Stores the container reference for later access by middleware and inject()
+
+   Call this during Django application startup (settings.py, apps.py ready(),
+   or wherever you create your NinjaAPI instance).
+
+   :param api: The NinjaAPI instance to configure. Currently unused but included
+               for API consistency and potential future use.
+   :param profile: Profile to scan with (e.g., ``Profile.PRODUCTION``). Accepts
+                   either a Profile enum value or a string profile name.
+   :param container: Optional Container instance. If not provided, uses the
+                     global ``dioxide.container`` singleton.
+   :param packages: Optional list of packages to scan for components. If not
+                    provided, scans all registered components.
+
+   :raises ImportError: If Django Ninja is not installed.
+
+   .. admonition:: Example
+
+      Basic setup::
+
+          from ninja import NinjaAPI
+          from dioxide import Profile
+          from dioxide.ninja import configure_dioxide
+
+          api = NinjaAPI()
+          configure_dioxide(api, profile=Profile.PRODUCTION)
+
+      With custom container::
+
+          from dioxide import Container, Profile
+          from dioxide.ninja import configure_dioxide
+
+          my_container = Container()
+          api = NinjaAPI()
+          configure_dioxide(api, profile=Profile.TEST, container=my_container)
+
+      With package scanning::
+
+          configure_dioxide(
+              api,
+              profile=Profile.PRODUCTION,
+              packages=['myapp.services', 'myapp.adapters'],
+          )
+
+   .. note::
+
+      You must also add ``DioxideMiddleware`` to your Django ``MIDDLEWARE``
+      setting for request scoping to work.
+
+   .. seealso::
+
+      - :class:`DioxideMiddleware` - Must be added to MIDDLEWARE
+      - :func:`inject` - How to inject dependencies in route handlers
+      - :class:`dioxide.container.ScopedContainer` - How scoping works
+
+
+.. py:class:: DioxideMiddleware(get_response)
+
+   Django middleware that creates a ScopedContainer per request.
+
+   This middleware handles request scoping for dioxide:
+
+   1. Creates a ``ScopedContainer`` before the view runs
+   2. Stores it in thread-local storage for ``inject()`` to access
+   3. Disposes the scope after the response is returned
+
+   Usage in settings.py::
+
+       MIDDLEWARE = [
+           ...
+           'dioxide.ninja.DioxideMiddleware',
+           ...
+       ]
+
+   .. note::
+
+      The middleware must be placed after any middleware that might need
+      dioxide services, as it creates the scope on request entry.
+
+   .. seealso::
+
+      - :func:`configure_dioxide` - Must be called first
+      - :func:`inject` - How to inject dependencies in route handlers
+      - :class:`dioxide.container.ScopedContainer` - The scoped container
+
+
+   .. py:attribute:: get_response
+
+
+   .. py:method:: __call__(request)
+
+      Process a request with dioxide scoping.
+
+      Creates a scoped container for the request, stores it in thread-local
+      storage, calls the view, and ensures cleanup on completion.
+
+      :param request: The Django HttpRequest object.
+
+      :returns: The HttpResponse from the view.
+
+
+
+.. py:function:: inject(component_type)
+
+   Resolve a component from the current request's dioxide scope.
+
+   This function retrieves a dependency from the dioxide container for
+   the current request. It automatically uses the correct scope:
+
+   - **SINGLETON**: Resolved from parent container (shared)
+   - **REQUEST**: Resolved from request scope (fresh per request)
+   - **FACTORY**: New instance each resolution
+
+   :param component_type: The type to resolve from the container
+
+   :returns: An instance of the requested type
+
+   :raises RuntimeError: If called outside a request context
+   :raises RuntimeError: If called without ``configure_dioxide()`` being set up
+   :raises ImportError: If Django Ninja is not installed
+
+   .. admonition:: Example
+
+      Basic usage::
+
+          from dioxide.ninja import inject
+
+
+          @api.get('/users')
+          def list_users(request):
+              service = inject(UserService)
+              return service.list_all()
+
+      Multiple dependencies::
+
+          @api.get('/dashboard')
+          def dashboard(request):
+              users = inject(UserService)
+              analytics = inject(AnalyticsService)
+              return {
+                  'users': users.count(),
+                  'visits': analytics.total_visits(),
+              }
+
+      Request-scoped dependencies::
+
+          from dioxide import service, Scope
+
+
+          @service(scope=Scope.REQUEST)
+          class RequestContext:
+              def __init__(self):
+                  self.request_id = str(uuid.uuid4())
+
+
+          @api.get('/test')
+          def test(request):
+              ctx = inject(RequestContext)
+              # ctx is unique per request
+              return {'request_id': ctx.request_id}
+
+   .. note::
+
+      This function uses ``inject()`` (lowercase) to match Django's naming
+      conventions and the existing ``dioxide.django`` integration. This is
+      different from FastAPI's ``Inject()`` pattern because Django Ninja
+      doesn't have built-in dependency injection like FastAPI's ``Depends``.
+
+   .. seealso::
+
+      - :func:`configure_dioxide` - Must be called first
+      - :class:`DioxideMiddleware` - Must be added to MIDDLEWARE
+      - :class:`dioxide.container.ScopedContainer` - How scoping works


### PR DESCRIPTION
## Summary

Updates sphinx-autoapi generated documentation to reflect current codebase state.

### New Framework Integrations
- **dioxide.celery** - Celery task scoping with `configure_dioxide()` and `scoped_task()`
- **dioxide.click** - Click CLI integration with `with_scope()` decorator
- **dioxide.django** - Django middleware and `inject()` helper
- **dioxide.fastapi** - FastAPI middleware and `Inject()` dependency
- **dioxide.flask** - Flask integration with request hooks
- **dioxide.ninja** - Django Ninja integration

### New API Additions
- `ScopedContainer` class for REQUEST-scoped resolution
- `CaptiveDependencyError` for scope validation at scan time
- `ScopeError` for runtime scope violations
- `Container.create_scope()` method
- `reset_global_container()` function
- Thread safety documentation

### Formatting
- Trailing whitespace cleanup in code examples (pre-commit hooks)

## Test Plan
- [x] Pre-commit hooks pass
- [ ] CI documentation checks pass
- [ ] Sphinx build succeeds