### PR TITLE
docs: Add golden path ASCII diagram to architecture page

### DIFF
--- a/docs/user_guide/architecture.md
+++ b/docs/user_guide/architecture.md
@@ -4,6 +4,43 @@ This page provides visual explanations of dioxide's hexagonal architecture patte
 comprehensive Mermaid diagrams. These diagrams illustrate how dioxide enables clean
 architecture through ports, adapters, profiles, and lifecycle management.
 
+## The Golden Path
+
+Before diving into detailed diagrams, here's the core mental model in one picture:
+
+```
+                    ┌─────────────────┐
+                    │    @service     │
+                    │   UserService   │
+                    │  (business      │
+                    │   logic)        │
+                    └────────┬────────┘
+                             │
+                             │ depends on
+                             ▼
+                    ┌─────────────────┐
+                    │   Port          │
+                    │   (Protocol)    │
+                    │   EmailPort     │
+                    └────────┬────────┘
+                             │
+            ┌────────────────┼────────────────┐
+            │                │                │
+            ▼                ▼                ▼
+    ┌───────────────┐ ┌───────────────┐ ┌───────────────┐
+    │  @adapter     │ │  @adapter     │ │  @adapter     │
+    │  PRODUCTION   │ │  TEST         │ │  DEVELOPMENT  │
+    │  SendGrid     │ │  FakeEmail    │ │  ConsoleEmail │
+    └───────────────┘ └───────────────┘ └───────────────┘
+```
+
+This is the Dependency Inversion Principle in action: your business logic (`@service`) depends
+on abstractions (Ports/Protocols), not concrete implementations. Adapters implement those ports
+for different environments. At runtime, dioxide wires the correct adapter based on the active
+profile - your service code never changes, only the adapters do.
+
+---
+
 ## Hexagonal Architecture Overview
 
 The hexagonal architecture (also known as ports-and-adapters) places your core business logic


### PR DESCRIPTION
## Summary

- Adds a simplified ASCII diagram to the architecture documentation that anchors the core mental model: Service -> Port <- Adapter
- Places "The Golden Path" section after the introduction, before detailed Mermaid diagrams
- Includes brief 3-sentence explanation of the Dependency Inversion Principle pattern

## Test plan

- [x] ASCII diagram renders correctly in Sphinx HTML output
- [x] Documentation builds without warnings related to the change
- [x] Diagram is properly placed in the document structure (after intro, before Mermaid sections)

Fixes #292