### PR TITLE
fix: Synchronize version to 1.0.1

### DIFF
--- a/python/dioxide/__init__.py
+++ b/python/dioxide/__init__.py
@@ -61,7 +61,7 @@ from .scope import Scope
 from .services import service
 from .testing import fresh_container
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 __all__ = [
     'AdapterNotFoundError',
     'CaptiveDependencyError',


### PR DESCRIPTION
## Summary

- Update `__version__` in `python/dioxide/__init__.py` from `'1.0.0'` to `'1.0.1'`
- Cargo.toml was already at `1.0.1` (no change needed)

## Problem

ReadTheDocs was displaying "dioxide 1.0.0 documentation" instead of "dioxide 1.0.1 documentation" because the Python package version was not updated after the v1.0.1 release.

## Test plan

- [x] Version string updated in `python/dioxide/__init__.py`
- [x] Cargo.toml version verified (already correct)
- [x] Pre-commit hooks pass

Fixes #304