### PR TITLE
feat: Terse error messages (1-3 lines max)

### DIFF
--- a/tests/test_descriptive_errors.py
+++ b/tests/test_descriptive_errors.py
@@ -128,8 +128,8 @@ class DescribeServiceNotFoundError:
         assert 'UserService' in error_msg
         # Should mention the missing dependency
         assert 'DatabasePort' in error_msg
-        # Should be helpful
-        assert 'dependencies' in error_msg.lower() or 'could not be resolved' in error_msg.lower()
+        # Should indicate missing dependency (terse format)
+        assert 'missing dependency' in error_msg.lower() or 'dependency' in error_msg.lower()
 
     def it_raises_when_component_not_registered(self) -> None:
         """Raises ServiceNotFoundError when trying to resolve unregistered component."""

--- a/tests/test_scoped_container.py
+++ b/tests/test_scoped_container.py
@@ -69,7 +69,7 @@ class DescribeScopedContainerCreation:
 
         async with container.create_scope() as outer_scope:
             # Trying to create nested scope should raise ScopeError
-            with pytest.raises(ScopeError, match='Nested scopes are not supported'):
+            with pytest.raises(ScopeError, match='Nested scopes not supported'):
                 async with outer_scope.create_scope():
                     pass
 
@@ -212,7 +212,7 @@ class DescribeRequestScopeOutsideScope:
 
     @pytest.mark.asyncio
     async def it_provides_helpful_error_message_for_request_outside_scope(self) -> None:
-        """Error message explains how to fix REQUEST outside scope."""
+        """Error message explains REQUEST scope requirement (terse format)."""
 
         @service(scope=Scope.REQUEST)
         class RequestContext:
@@ -225,13 +225,12 @@ class DescribeRequestScopeOutsideScope:
             container.resolve(RequestContext)
 
         error_message = str(exc_info.value)
-        # Error should mention:
+        # Error should mention (terse format):
         # 1. The component that failed
         assert 'RequestContext' in error_message
-        # 2. That it's REQUEST scoped
+        # 2. That it's REQUEST scoped and requires active scope
         assert 'REQUEST' in error_message
-        # 3. How to fix (create_scope)
-        assert 'create_scope' in error_message
+        assert 'scope' in error_message.lower()
 
 
 class DescribeCaptiveDependency:

--- a/tests/test_terse_errors.py
+++ b/tests/test_terse_errors.py
@@ -1,0 +1,414 @@
+"""Tests for terse error messages (1-3 lines max at runtime).
+
+This module tests that all dioxide exceptions produce terse, actionable
+error messages at runtime. Verbose explanations remain in docstrings only.
+
+Issue #312: Runtime errors should be 1-3 lines max, with key diagnostic info preserved.
+"""
+
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Protocol,
+)
+
+import pytest
+
+from dioxide import (
+    Container,
+    Profile,
+    adapter,
+    lifecycle,
+    service,
+)
+from dioxide.exceptions import (
+    AdapterNotFoundError,
+    CaptiveDependencyError,
+    ScopeError,
+    ServiceNotFoundError,
+)
+from dioxide.scope import Scope
+
+if TYPE_CHECKING:
+    pass
+
+
+# Module-level classes for CircularDependencyError tests
+# These must be at module level for forward references to resolve properly
+@service
+@lifecycle
+class _TerseTestCircularA:
+    def __init__(self, b: _TerseTestCircularB) -> None:
+        self.b = b
+
+    async def initialize(self) -> None:
+        pass
+
+    async def dispose(self) -> None:
+        pass
+
+
+@service
+@lifecycle
+class _TerseTestCircularB:
+    def __init__(self, a: _TerseTestCircularA) -> None:
+        self.a = a
+
+    async def initialize(self) -> None:
+        pass
+
+    async def dispose(self) -> None:
+        pass
+
+
+class EmailPort(Protocol):
+    """Test protocol for email adapters."""
+
+    async def send(self, to: str, subject: str, body: str) -> None:
+        """Send an email message."""
+        ...
+
+
+class DatabasePort(Protocol):
+    """Test protocol for database adapters."""
+
+    def query(self, sql: str) -> list[dict[str, Any]]:
+        """Execute a database query."""
+        ...
+
+
+class DescribeTerseAdapterNotFoundError:
+    """Tests for terse AdapterNotFoundError messages."""
+
+    def it_produces_message_under_4_lines(self) -> None:
+        """Error message is 1-3 lines maximum."""
+
+        @adapter.for_(EmailPort, profile=Profile.PRODUCTION)
+        class SendGridAdapter:
+            async def send(self, to: str, subject: str, body: str) -> None:
+                pass
+
+        container = Container()
+        container.scan(profile=Profile.TEST)
+
+        with pytest.raises(AdapterNotFoundError) as exc_info:
+            container.resolve(EmailPort)
+
+        error_msg = str(exc_info.value)
+        line_count = len(error_msg.strip().split('\n'))
+        assert line_count <= 3, f'Error message has {line_count} lines, expected <= 3:\n{error_msg}'
+
+    def it_includes_port_name_and_profile(self) -> None:
+        """Error message includes port name and active profile on first line."""
+
+        @adapter.for_(EmailPort, profile=Profile.PRODUCTION)
+        class SendGridAdapter:
+            async def send(self, to: str, subject: str, body: str) -> None:
+                pass
+
+        container = Container()
+        container.scan(profile=Profile.TEST)
+
+        with pytest.raises(AdapterNotFoundError) as exc_info:
+            container.resolve(EmailPort)
+
+        error_msg = str(exc_info.value)
+        first_line = error_msg.split('\n')[0]
+        assert 'EmailPort' in first_line
+        assert 'test' in first_line.lower()
+
+    def it_shows_registered_adapters_for_other_profiles(self) -> None:
+        """Second line shows what adapters ARE registered (for other profiles)."""
+
+        @adapter.for_(EmailPort, profile=Profile.PRODUCTION)
+        class SendGridAdapter:
+            async def send(self, to: str, subject: str, body: str) -> None:
+                pass
+
+        container = Container()
+        container.scan(profile=Profile.TEST)
+
+        with pytest.raises(AdapterNotFoundError) as exc_info:
+            container.resolve(EmailPort)
+
+        error_msg = str(exc_info.value)
+        # Should show registered adapters
+        assert 'SendGridAdapter' in error_msg
+        assert 'production' in error_msg.lower()
+
+    def it_does_not_include_code_examples(self) -> None:
+        """Error message does NOT include code examples or hints."""
+
+        @adapter.for_(EmailPort, profile=Profile.PRODUCTION)
+        class SendGridAdapter:
+            async def send(self, to: str, subject: str, body: str) -> None:
+                pass
+
+        container = Container()
+        container.scan(profile=Profile.TEST)
+
+        with pytest.raises(AdapterNotFoundError) as exc_info:
+            container.resolve(EmailPort)
+
+        error_msg = str(exc_info.value)
+        # Should NOT have code examples or verbose hints
+        assert '@adapter.for_' not in error_msg
+        assert 'class YourAdapter' not in error_msg
+        assert 'Hint:' not in error_msg
+
+
+class DescribeTerseServiceNotFoundError:
+    """Tests for terse ServiceNotFoundError messages."""
+
+    def it_produces_message_under_4_lines(self) -> None:
+        """Error message is 1-3 lines maximum."""
+
+        @service
+        class UserService:
+            def __init__(self, db: DatabasePort):
+                self.db = db
+
+        container = Container()
+        container.scan(profile=Profile.TEST)
+
+        with pytest.raises(ServiceNotFoundError) as exc_info:
+            container.resolve(UserService)
+
+        error_msg = str(exc_info.value)
+        line_count = len(error_msg.strip().split('\n'))
+        assert line_count <= 3, f'Error message has {line_count} lines, expected <= 3:\n{error_msg}'
+
+    def it_includes_service_name_and_missing_dependency(self) -> None:
+        """Error message includes service name and what dependency is missing."""
+
+        @service
+        class UserService:
+            def __init__(self, db: DatabasePort):
+                self.db = db
+
+        container = Container()
+        container.scan(profile=Profile.TEST)
+
+        with pytest.raises(ServiceNotFoundError) as exc_info:
+            container.resolve(UserService)
+
+        error_msg = str(exc_info.value)
+        assert 'UserService' in error_msg
+        assert 'DatabasePort' in error_msg
+
+    def it_includes_profile_context(self) -> None:
+        """Error message includes the active profile."""
+
+        @service
+        class OrderService:
+            def __init__(self, email: EmailPort):
+                self.email = email
+
+        container = Container()
+        container.scan(profile=Profile.PRODUCTION)
+
+        with pytest.raises(ServiceNotFoundError) as exc_info:
+            container.resolve(OrderService)
+
+        error_msg = str(exc_info.value)
+        assert 'production' in error_msg.lower()
+
+    def it_does_not_include_code_examples_for_unregistered(self) -> None:
+        """Error message does NOT include code examples for unregistered services."""
+
+        class UnregisteredService:
+            pass
+
+        container = Container()
+        container.scan(profile=Profile.TEST)
+
+        with pytest.raises(ServiceNotFoundError) as exc_info:
+            container.resolve(UnregisteredService)
+
+        error_msg = str(exc_info.value)
+        # Should NOT have multi-line code examples
+        assert 'class UnregisteredService' not in error_msg
+        assert 'Hint:' not in error_msg
+        # Can mention @service briefly but not as code block
+        assert '  @service' not in error_msg  # No indented code example
+
+
+class DescribeTerseCircularDependencyError:
+    """Tests for terse CircularDependencyError messages.
+
+    Note: Circular dependencies in @lifecycle components are caught during resolution,
+    raising ServiceNotFoundError rather than CircularDependencyError. The
+    CircularDependencyError is raised during topological sorting in
+    _build_lifecycle_dependency_order() but this is effectively a dead code path
+    since resolution catches cycles first.
+
+    These tests verify the terse format of the error message by testing the
+    ServiceNotFoundError that gets raised for circular dependencies.
+    """
+
+    def it_produces_terse_message_for_circular_dependency(self) -> None:
+        """Error message for circular dependency is terse (1-3 lines)."""
+        # Module-level classes: _TerseTestCircularA <-> _TerseTestCircularB
+        container = Container()
+        container.scan()
+
+        # Circular deps raise ServiceNotFoundError during resolution
+        with pytest.raises(ServiceNotFoundError) as exc_info:
+            container.resolve(_TerseTestCircularA)
+
+        error_msg = str(exc_info.value)
+        line_count = len(error_msg.strip().split('\n'))
+        assert line_count <= 3, f'Error message has {line_count} lines, expected <= 3:\n{error_msg}'
+
+    def it_mentions_component_in_cycle(self) -> None:
+        """Error message mentions the component that couldn't be resolved."""
+        container = Container()
+        container.scan()
+
+        with pytest.raises(ServiceNotFoundError) as exc_info:
+            container.resolve(_TerseTestCircularA)
+
+        error_msg = str(exc_info.value)
+        assert '_TerseTestCircularA' in error_msg or '_TerseTestCircularB' in error_msg
+
+
+class DescribeTerseScopeError:
+    """Tests for terse ScopeError messages."""
+
+    def it_produces_message_under_4_lines_for_request_scope(self) -> None:
+        """Error message is 1-3 lines maximum for REQUEST scope violations."""
+
+        @service(scope=Scope.REQUEST)
+        class RequestContext:
+            pass
+
+        container = Container()
+        container.scan(profile=Profile.TEST)
+
+        with pytest.raises(ScopeError) as exc_info:
+            container.resolve(RequestContext)
+
+        error_msg = str(exc_info.value)
+        line_count = len(error_msg.strip().split('\n'))
+        assert line_count <= 3, f'Error message has {line_count} lines, expected <= 3:\n{error_msg}'
+
+    def it_mentions_component_and_scope_requirement(self) -> None:
+        """Error message mentions the component and that it requires a scope."""
+
+        @service(scope=Scope.REQUEST)
+        class RequestData:
+            pass
+
+        container = Container()
+        container.scan(profile=Profile.TEST)
+
+        with pytest.raises(ScopeError) as exc_info:
+            container.resolve(RequestData)
+
+        error_msg = str(exc_info.value)
+        assert 'RequestData' in error_msg
+        assert 'REQUEST' in error_msg or 'scope' in error_msg.lower()
+
+    def it_does_not_include_code_examples(self) -> None:
+        """Error message does NOT include code examples."""
+
+        @service(scope=Scope.REQUEST)
+        class ScopedComponent:
+            pass
+
+        container = Container()
+        container.scan(profile=Profile.TEST)
+
+        with pytest.raises(ScopeError) as exc_info:
+            container.resolve(ScopedComponent)
+
+        error_msg = str(exc_info.value)
+        assert 'async with' not in error_msg
+        assert 'Hint:' not in error_msg
+
+    @pytest.mark.asyncio
+    async def it_produces_terse_message_for_nested_scopes(self) -> None:
+        """Error message for nested scope attempt is terse."""
+        container = Container()
+        container.scan(profile=Profile.TEST)
+
+        # ScopedContainer.create_scope() raises ScopeError for nested scopes
+        async with container.create_scope() as scope:
+            with pytest.raises(ScopeError) as exc_info:
+                scope.create_scope()
+
+            error_msg = str(exc_info.value)
+            line_count = len(error_msg.strip().split('\n'))
+            assert line_count <= 3, f'Error message has {line_count} lines, expected <= 3:\n{error_msg}'
+
+
+class DescribeTerseCaptiveDependencyError:
+    """Tests for terse CaptiveDependencyError messages."""
+
+    def it_produces_message_under_4_lines(self) -> None:
+        """Error message is 1-3 lines maximum."""
+
+        @service(scope=Scope.REQUEST)
+        class RequestCtx:
+            pass
+
+        @service  # SINGLETON by default
+        class GlobalService:
+            def __init__(self, ctx: RequestCtx):
+                self.ctx = ctx
+
+        container = Container()
+
+        with pytest.raises(CaptiveDependencyError) as exc_info:
+            container.scan(profile=Profile.TEST)
+
+        error_msg = str(exc_info.value)
+        line_count = len(error_msg.strip().split('\n'))
+        assert line_count <= 3, f'Error message has {line_count} lines, expected <= 3:\n{error_msg}'
+
+    def it_names_both_components_and_their_scopes(self) -> None:
+        """Error message names parent (SINGLETON) and child (REQUEST) components."""
+
+        @service(scope=Scope.REQUEST)
+        class ReqCtx:
+            pass
+
+        @service  # SINGLETON
+        class SingletonSvc:
+            def __init__(self, ctx: ReqCtx):
+                self.ctx = ctx
+
+        container = Container()
+
+        with pytest.raises(CaptiveDependencyError) as exc_info:
+            container.scan(profile=Profile.TEST)
+
+        error_msg = str(exc_info.value)
+        assert 'SingletonSvc' in error_msg
+        assert 'ReqCtx' in error_msg
+        assert 'SINGLETON' in error_msg
+        assert 'REQUEST' in error_msg
+
+    def it_does_not_include_solution_examples(self) -> None:
+        """Error message does NOT include solution code examples."""
+
+        @service(scope=Scope.REQUEST)
+        class ReqScope:
+            pass
+
+        @service
+        class CaptiveParent:
+            def __init__(self, req: ReqScope):
+                self.req = req
+
+        container = Container()
+
+        with pytest.raises(CaptiveDependencyError) as exc_info:
+            container.scan(profile=Profile.TEST)
+
+        error_msg = str(exc_info.value)
+        assert 'Solutions:' not in error_msg
+        assert '@service(scope=Scope.REQUEST)' not in error_msg
+        assert 'factory/provider' not in error_msg.lower()


### PR DESCRIPTION
## Summary

- Refactored all exception messages from 20+ lines to 1-3 lines maximum
- Key diagnostic information preserved (profile, what's registered)
- Full explanations remain in docstrings for documentation
- Consistent error message format across all exceptions

### Error Message Format

```
{ExceptionType}: {one-line summary}
  {key diagnostic fact 1}
  {key diagnostic fact 2}
```

### Example Before
```
No adapter registered for port EmailPort with profile 'test'.

Available adapters for EmailPort:
  SendGridAdapter (profiles: production)

Hint: Add an adapter for profile 'test':
  @adapter.for_(EmailPort, profile='test')
```

### Example After
```
No adapter for EmailPort in profile 'test'
  Registered: SendGridAdapter (production)
```

## Test plan
- [x] 17 new tests for terse error message format
- [x] All 405 existing tests pass
- [x] Tests verify messages are under 4 lines
- [x] Tests verify key diagnostic info preserved
- [x] Tests verify no code examples in runtime messages

Fixes #312

🤖 Generated with [Claude Code](https://claude.ai/code)