### PR TITLE
docs: Add @service vs @adapter decision tree and mental model

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,19 @@ assert fake_email.sent_emails[0]["to"] == "test@example.com"
 - **Profiles** (`Profile.PRODUCTION`, `Profile.TEST`): Environment selection
 - **Container**: Auto-wires dependencies based on type hints
 
+### When to Use @service vs @adapter
+
+| Use `@service` when... | Use `@adapter.for_()` when... |
+|------------------------|-------------------------------|
+| Writing core business logic | Connecting to external systems |
+| Component is the same across all environments | Different implementations needed per profile |
+| Implementing domain rules and use cases | Implementing a Port (Protocol) contract |
+| Example: `UserService`, `OrderProcessor` | Example: `SendGridAdapter`, `PostgresRepository` |
+
+**The key insight:** Services ARE the abstraction (core domain). Adapters IMPLEMENT abstractions (ports) for different environments.
+
+See the [full guide on @service vs @adapter](https://dioxide.readthedocs.io/en/latest/user_guide/services-vs-adapters/) for decision trees and detailed examples.
+
 ## Constructor Dependency Injection
 
 When you create an adapter or service with constructor parameters, dioxide **automatically injects dependencies** based on type hints. This is the core mechanism that makes dependency injection "just work".

--- a/docs/index.md
+++ b/docs/index.md
@@ -298,6 +298,7 @@ philosophy
 :caption: User Guide
 
 user_guide/getting_started
+user_guide/services-vs-adapters
 user_guide/hexagonal_architecture
 user_guide/architecture
 user_guide/testing_with_fakes

--- a/docs/user_guide/services-vs-adapters.md
+++ b/docs/user_guide/services-vs-adapters.md
@@ -1,0 +1,345 @@
+# Understanding @service vs @adapter
+
+This guide clarifies the mental model for when to use `@service` versus `@adapter.for_()` decorators in dioxide.
+
+## The Decision Tree
+
+Use this flowchart when deciding which decorator to apply.
+
+```
+Do you need to swap implementations based on profile (test/prod/dev)?
+├── YES → Define a Port (Protocol) + use @adapter.for_(Port, profile=...)
+│         Examples: Database, Email, Payment Gateway, External APIs
+│
+└── NO → Use @service
+         Examples: Business logic, Domain services, Use cases
+
+Is this core business logic that shouldn't change between environments?
+├── YES → @service
+└── NO → @adapter.for_(Port)
+
+Does this component talk to external systems (DB, network, filesystem)?
+├── YES → Port + @adapter (allows faking in tests)
+└── NO → Probably @service
+```
+
+## The Mental Model
+
+Understanding the relationship between services, ports, and adapters is fundamental to dioxide and hexagonal architecture.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Hexagonal Architecture                       │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│   External World          │  Application Core  │  External World │
+│   (Driving Side)          │                    │  (Driven Side)  │
+│                           │                    │                  │
+│   ┌─────────┐            │   ┌──────────┐    │   ┌─────────┐   │
+│   │ FastAPI │──adapter──>│   │ @service │────│──>│  Port   │   │
+│   │ Click   │            │   │ (core    │    │   │(Protocol)│   │
+│   │ Flask   │            │   │  logic)  │    │   └────┬────┘   │
+│   └─────────┘            │   └──────────┘    │        │        │
+│                           │                    │   ┌────▼────┐   │
+│                           │                    │   │ @adapter │   │
+│                           │                    │   │(implements│  │
+│                           │                    │   │   port)  │   │
+│                           │                    │   └─────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### @service: The Core
+
+Services represent **core business logic** - the domain rules that define your application's behavior. They sit at the center of the hexagon.
+
+**Key characteristics of @service:**
+
+| Characteristic | Description |
+|----------------|-------------|
+| **Singleton** | One shared instance across the application |
+| **Profile-agnostic** | Available in ALL profiles (production, test, development) |
+| **Depends on Ports** | Uses Protocol types, not concrete implementations |
+| **Pure business logic** | No knowledge of databases, APIs, or infrastructure |
+
+**Why @service doesn't require a port:**
+
+Services ARE the abstraction. They represent your domain logic, which doesn't need to be swapped based on environment. The same `UserService` runs in production and tests - only its *dependencies* (the ports) change.
+
+### @adapter.for_(): The Boundaries
+
+Adapters are **concrete implementations** of ports that connect your application to the outside world. They live at the hexagon's edges.
+
+**Key characteristics of @adapter.for_():**
+
+| Characteristic | Description |
+|----------------|-------------|
+| **Profile-specific** | Different adapter per environment |
+| **Implements a Port** | Satisfies a Protocol contract |
+| **Singleton by default** | One instance per profile (can be overridden) |
+| **Infrastructure code** | Talks to databases, APIs, filesystems |
+
+**Why @adapter requires a port:**
+
+Adapters implement abstractions (ports). Multiple adapters can satisfy the same port contract - one for production (real database), one for testing (in-memory), one for development (local file). The container selects the right one based on the active profile.
+
+### Ports: The Contracts
+
+Ports are **interfaces** (Python Protocols) that define contracts between your core and the outside world.
+
+**Important:** Ports have NO decorator. They're just type definitions.
+
+```python
+from typing import Protocol
+
+class EmailPort(Protocol):
+    """Port defining email operations - no decorator needed."""
+    async def send(self, to: str, subject: str, body: str) -> None: ...
+```
+
+## Practical Examples
+
+### Example 1: Email System
+
+**Port (the interface):**
+```python
+from typing import Protocol
+
+class EmailPort(Protocol):
+    async def send(self, to: str, subject: str, body: str) -> None: ...
+```
+
+**Adapters (profile-specific implementations):**
+```python
+from dioxide import adapter, Profile
+
+@adapter.for_(EmailPort, profile=Profile.PRODUCTION)
+class SendGridAdapter:
+    """Real email via SendGrid API."""
+    async def send(self, to: str, subject: str, body: str) -> None:
+        # Real API calls
+        ...
+
+@adapter.for_(EmailPort, profile=Profile.TEST)
+class FakeEmailAdapter:
+    """Fast fake for testing."""
+    def __init__(self):
+        self.sent_emails = []
+
+    async def send(self, to: str, subject: str, body: str) -> None:
+        self.sent_emails.append({"to": to, "subject": subject, "body": body})
+
+@adapter.for_(EmailPort, profile=Profile.DEVELOPMENT)
+class ConsoleEmailAdapter:
+    """Console logging for development."""
+    async def send(self, to: str, subject: str, body: str) -> None:
+        print(f"EMAIL TO: {to}\nSUBJECT: {subject}")
+```
+
+**Service (core business logic):**
+```python
+from dioxide import service
+
+@service
+class NotificationService:
+    """Business logic - depends on EmailPort, not concrete adapter."""
+    def __init__(self, email: EmailPort):
+        self.email = email  # Could be SendGrid, Fake, or Console
+
+    async def send_welcome(self, user_email: str, user_name: str) -> None:
+        # Business rule: validate email
+        if "@" not in user_email:
+            raise ValueError("Invalid email")
+
+        # Delegate to port - service doesn't know/care which adapter
+        await self.email.send(
+            to=user_email,
+            subject="Welcome!",
+            body=f"Hello {user_name}, welcome to our service!"
+        )
+```
+
+### Example 2: Configuration
+
+Sometimes you need something that IS a service (singleton, profile-agnostic) but also loads from environment:
+
+```python
+from dioxide import service
+from pydantic_settings import BaseSettings
+
+@service
+class AppConfig(BaseSettings):
+    """Configuration - it's a service, not an adapter.
+
+    Why @service?
+    - Same config class runs in all profiles
+    - Doesn't implement a port
+    - Just stores configuration values
+    """
+    database_url: str = "sqlite:///dev.db"
+    sendgrid_api_key: str = ""
+```
+
+### Example 3: Repository Pattern
+
+**Port:**
+```python
+class UserRepository(Protocol):
+    async def save(self, user: dict) -> None: ...
+    async def find_by_id(self, user_id: str) -> dict | None: ...
+```
+
+**Production adapter:**
+```python
+@adapter.for_(UserRepository, profile=Profile.PRODUCTION)
+class PostgresUserRepository:
+    """Real database."""
+    def __init__(self, db: Database):
+        self.db = db
+
+    async def save(self, user: dict) -> None:
+        # Real SQL
+        ...
+```
+
+**Test adapter:**
+```python
+@adapter.for_(UserRepository, profile=Profile.TEST)
+class InMemoryUserRepository:
+    """Fast fake - no database needed."""
+    def __init__(self):
+        self.users = {}
+
+    async def save(self, user: dict) -> None:
+        self.users[user["id"]] = user
+
+    async def find_by_id(self, user_id: str) -> dict | None:
+        return self.users.get(user_id)
+
+    def seed(self, *users: dict) -> None:
+        """Test helper - seed with test data."""
+        for user in users:
+            self.users[user["id"]] = user
+```
+
+## Quick Reference Table
+
+| Question | @service | @adapter.for_() |
+|----------|----------|-----------------|
+| **What is it?** | Core domain logic | Boundary implementation |
+| **Requires a port?** | No | Yes |
+| **Profile-specific?** | No (same in all profiles) | Yes (different per profile) |
+| **Scope** | Singleton | Singleton (default) |
+| **Dependencies** | Depends on Ports | May depend on services or other adapters |
+| **Testing** | Same service, different adapters injected | Different adapter per profile |
+
+## Common Patterns
+
+### Pattern 1: Service Depends on Multiple Ports
+
+```python
+@service
+class OrderService:
+    def __init__(
+        self,
+        orders: OrderRepository,
+        payments: PaymentGateway,
+        email: EmailPort,
+        clock: ClockPort
+    ):
+        # All dependencies are ports - injectable via profiles
+        self.orders = orders
+        self.payments = payments
+        self.email = email
+        self.clock = clock
+
+    async def process_order(self, order_id: str) -> None:
+        # Pure business logic using ports
+        order = await self.orders.find_by_id(order_id)
+        await self.payments.charge(order["amount"], order["card_token"])
+        await self.email.send(order["customer_email"], "Order Confirmed", "...")
+```
+
+### Pattern 2: Adapter Depends on Configuration
+
+```python
+@adapter.for_(PaymentGateway, profile=Profile.PRODUCTION)
+class StripeAdapter:
+    def __init__(self, config: AppConfig):
+        # Adapters can depend on services like AppConfig
+        self.api_key = config.stripe_api_key
+```
+
+### Pattern 3: Adapter for Multiple Profiles
+
+```python
+@adapter.for_(CachePort, profile=[Profile.TEST, Profile.DEVELOPMENT])
+class InMemoryCacheAdapter:
+    """Simple cache for both test and dev environments."""
+    def __init__(self):
+        self._cache = {}
+```
+
+## Anti-Patterns to Avoid
+
+### Anti-Pattern 1: Service with Infrastructure
+
+```python
+# BAD - service contains infrastructure
+@service
+class UserService:
+    async def register(self, email: str) -> None:
+        # Don't do this!
+        conn = psycopg2.connect("dbname=prod")  # Infrastructure in service!
+        sendgrid.send(to=email, subject="Welcome!")  # More infrastructure!
+```
+
+**Fix:** Depend on ports instead.
+
+### Anti-Pattern 2: Adapter with Business Logic
+
+```python
+# BAD - adapter contains business logic
+@adapter.for_(EmailPort, profile=Profile.PRODUCTION)
+class SendGridAdapter:
+    async def send(self, to: str, subject: str, body: str) -> None:
+        # Don't put business rules here!
+        if "@" not in to:
+            raise ValueError("Invalid email")  # This is a business rule!
+        # ... actual sending
+```
+
+**Fix:** Move business logic to the service.
+
+### Anti-Pattern 3: Service that Should Be an Adapter
+
+```python
+# BAD - this should be an adapter
+@service
+class EmailSender:
+    async def send(self, to: str, subject: str, body: str) -> None:
+        # This talks to external systems - should be an adapter!
+        async with httpx.AsyncClient() as client:
+            await client.post("https://api.sendgrid.com/...")
+```
+
+**Fix:** Create a port and use `@adapter.for_()`.
+
+## Summary
+
+**Use @service when:**
+- Implementing core business logic
+- The component shouldn't change between environments
+- You're writing domain rules and use cases
+
+**Use @adapter.for_() when:**
+- Connecting to external systems (DB, API, filesystem)
+- You need different implementations for different profiles
+- You want to swap real implementations for fakes in tests
+
+**The key insight:** Services depend on ports (abstractions), adapters implement ports (concrete). This IS the Dependency Inversion Principle in action.
+
+## Next Steps
+
+- Read [Hexagonal Architecture with dioxide](hexagonal_architecture.md) for the full picture
+- See [Testing with Fakes](testing_with_fakes.rst) for testing patterns
+- Check the [API Reference](../api/dioxide/index.rst) for decorator details

--- a/python/dioxide/adapter.py
+++ b/python/dioxide/adapter.py
@@ -4,6 +4,30 @@ The @adapter decorator enables marking concrete implementations (adapters) for
 Protocol/ABC ports with explicit profile associations, supporting hexagonal
 (ports-and-adapters) architecture patterns.
 
+When to Use @adapter.for_():
+    Use @adapter.for_() when you are implementing a **boundary component** that:
+
+    - **Connects to external systems** (databases, APIs, filesystems, network)
+    - Needs **different implementations per profile** (production, test, development)
+    - **Implements a port** (Protocol/ABC) contract
+    - Should be **swappable** without changing business logic
+
+    Do NOT use @adapter.for_() if:
+
+    - The component is core business logic (use @service instead)
+    - The component should be the same across all environments (use @service)
+    - You're not implementing a port interface
+
+    **Decision Tree**::
+
+        Do you need different implementations based on profile (test/prod/dev)?
+        |-- YES --> Define a Port (Protocol) + use @adapter.for_(Port, profile=...)
+        |-- NO  --> Use @service
+
+        Does this component talk to external systems (DB, network, filesystem)?
+        |-- YES --> Port + @adapter.for_() (allows faking in tests)
+        |-- NO  --> Probably @service
+
 In hexagonal architecture:
     - **Ports** are abstract interfaces (Protocols/ABCs) that define contracts
     - **Adapters** are concrete implementations that fulfill port contracts

--- a/python/dioxide/services.py
+++ b/python/dioxide/services.py
@@ -5,6 +5,27 @@ Services represent the business rules layer that sits between ports (interfaces)
 adapters (implementations), containing the core application logic that doesn't depend
 on infrastructure details.
 
+When to Use @service:
+    Use @service when you are writing **core business logic** that:
+
+    - Should be the **same across all environments** (production, test, development)
+    - Contains **domain rules** and **use cases**
+    - **Does NOT talk directly** to external systems (databases, APIs, filesystems)
+    - **Depends on ports** (Protocols/ABCs) for infrastructure needs
+
+    Do NOT use @service if you need different implementations per profile.
+    Use @adapter.for_() instead.
+
+    **Decision Tree**::
+
+        Is this core business logic that shouldn't change between environments?
+        |-- YES --> Use @service
+        |-- NO  --> Use @adapter.for_(Port, profile=...)
+
+        Does this component talk directly to external systems?
+        |-- YES --> Use @adapter.for_(Port, profile=...)
+        |-- NO  --> Probably @service
+
 Key Characteristics:
     - **Singleton scope**: One shared instance across the application
     - **Profile-agnostic**: Available in ALL profiles (production, test, development)


### PR DESCRIPTION
## Summary

- Add comprehensive guide explaining when to use `@service` vs `@adapter`
- Create decision tree flowchart for decorator selection
- Add mental model diagram showing hexagonal architecture relationships
- Update docstrings in `services.py` and `adapter.py` with "when to use" guidance
- Add quick reference section to README

## Changes

### New Documentation
- `docs/user_guide/services-vs-adapters.md` - Full guide with:
  - Decision tree flowchart
  - ASCII diagram of hexagonal architecture
  - Practical examples (email system, configuration, repository pattern)
  - Quick reference table
  - Common patterns and anti-patterns

### Updated Files
- `docs/index.md` - Added link to new guide
- `README.md` - Added "When to Use @service vs @adapter" section
- `python/dioxide/services.py` - Enhanced module docstring
- `python/dioxide/adapter.py` - Enhanced module docstring

## Test plan
- [x] All 441 existing tests pass
- [x] Documentation builds successfully
- [x] Links in docs are valid

Fixes #314