### PR TITLE
feat: Add real-world pattern examples and migration guides

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,32 @@
 # dioxide Examples
 
-This directory contains working examples demonstrating dioxide's hexagonal architecture patterns.
+This directory contains working examples demonstrating dioxide's hexagonal architecture patterns,
+real-world usage scenarios, and migration guides from other DI frameworks.
+
+## Directory Structure
+
+```
+examples/
+├── README.md                    # This file
+├── getting_started_example.py   # Quick start example
+├── hexagonal_architecture.py    # Complete hexagonal architecture demo
+│
+├── patterns/                    # Real-world patterns
+│   ├── dependency-chain/        # Multi-service dependency chains
+│   ├── circular-deps/           # Circular dependency detection/fixes
+│   ├── caching/                 # Caching adapter pattern
+│   └── external-api/            # External API with error injection
+│
+├── migrations/                  # Framework migration guides
+│   ├── from-dependency-injector/  # Migration from dependency-injector
+│   └── from-injector/             # Migration from injector
+│
+└── [framework integrations]/    # FastAPI, Flask, Celery, Click
+    ├── fastapi/
+    ├── flask/
+    ├── celery/
+    └── click/
+```
 
 ## Running the Examples
 
@@ -20,6 +46,134 @@ maturin develop
 # Run examples from repository root
 python examples/hexagonal_architecture.py
 ```
+
+---
+
+## Pattern Examples
+
+### Multi-Service Dependency Chain
+
+**Location:** `patterns/dependency-chain/`
+
+Demonstrates complex service dependencies: `OrderController -> OrderService -> [OrderRepository, ProductRepository, Cache, EventPublisher]`
+
+```bash
+# Run the example
+python examples/patterns/dependency-chain/app/main.py
+
+# Run tests
+uv run pytest examples/patterns/dependency-chain/tests/ -v
+```
+
+**Key concepts:**
+- Services depending on multiple ports
+- Deep dependency trees resolved automatically
+- Test isolation with fresh containers
+
+### Circular Dependency Detection
+
+**Location:** `patterns/circular-deps/`
+
+Shows how dioxide detects circular dependencies and provides solutions using event-based patterns.
+
+**Files:**
+- `problem.py` - Demonstrates the circular dependency error
+- `solution.py` - Shows the fix using events
+
+```bash
+# See the error
+python examples/patterns/circular-deps/problem.py
+
+# See the solution
+python examples/patterns/circular-deps/solution.py
+```
+
+### Caching Adapter Pattern
+
+**Location:** `patterns/caching/`
+
+Demonstrates the caching adapter pattern where a `CachingUserRepository` wraps the real repository.
+
+```bash
+# Run the example
+python examples/patterns/caching/app/main.py
+
+# Run tests
+uv run pytest examples/patterns/caching/tests/ -v
+```
+
+**Key concepts:**
+- Decorator pattern for cross-cutting concerns
+- Cache-aside pattern with dioxide
+- Fake cache for testing with hit/miss tracking
+
+### External API Integration
+
+**Location:** `patterns/external-api/`
+
+Complete payment gateway integration with error injection for testing various failure scenarios.
+
+```bash
+# Run the example
+python examples/patterns/external-api/app/main.py
+
+# Run tests
+uv run pytest examples/patterns/external-api/tests/ -v
+```
+
+**Key concepts:**
+- Error injection pattern for testing failures
+- Transient failure simulation with retry logic
+- Rate limiting and network error handling
+- Domain-specific error types
+
+---
+
+## Migration Guides
+
+### From dependency-injector
+
+**Location:** `migrations/from-dependency-injector/`
+
+Complete before/after comparison showing migration from the `dependency-injector` library.
+
+**Structure:**
+- `before/` - Original code using `dependency-injector`
+- `after/` - Migrated code using `dioxide`
+
+**Key changes:**
+- Replace `Container` with provider definitions -> `@adapter.for_()` decorators
+- Replace ABC interfaces -> Protocols
+- Replace `providers.Singleton/Factory` -> `scope` parameter
+- Replace provider overrides -> `Profile.TEST`
+
+```bash
+# Run dioxide version tests
+uv run pytest examples/migrations/from-dependency-injector/after/tests/ -v
+```
+
+### From injector
+
+**Location:** `migrations/from-injector/`
+
+Complete before/after comparison showing migration from the `injector` library (Guice-inspired).
+
+**Structure:**
+- `before/` - Original code using `injector`
+- `after/` - Migrated code using `dioxide`
+
+**Key changes:**
+- Remove `@inject` decorators (dioxide infers from type hints)
+- Replace `Module` classes -> `@adapter.for_()` decorators
+- Replace `Injector([modules])` -> `Container().scan(profile=...)`
+- Replace `binder.bind()` -> profile-based registration
+
+```bash
+# Run dioxide version tests
+uv run pytest examples/migrations/from-injector/after/tests/ -v
+```
+
+---
 
 ### Hexagonal Architecture Example
 

--- a/examples/migrations/from-dependency-injector/README.md
+++ b/examples/migrations/from-dependency-injector/README.md
@@ -1,0 +1,188 @@
+# Migration from dependency-injector to dioxide
+
+This example demonstrates how to migrate from the `dependency-injector` library to dioxide,
+showing equivalent patterns and the simplifications that dioxide provides.
+
+## Overview
+
+`dependency-injector` is a popular Python DI framework that uses explicit container configuration
+with providers. dioxide takes a different approach with decorator-based registration and
+profile-based adapter selection.
+
+## Key Differences
+
+| Aspect | dependency-injector | dioxide |
+|--------|---------------------|---------|
+| **Container** | Class-based with explicit providers | Scan-based with decorators |
+| **Registration** | `providers.Factory`, `providers.Singleton` | `@adapter.for_()`, `@service` |
+| **Scoping** | Provider types determine lifecycle | `scope=Scope.SINGLETON/FACTORY` |
+| **Profiles** | Manual via different containers | Built-in `Profile` enum |
+| **Wiring** | `@inject` + container wiring | Constructor injection, automatic |
+| **Testing** | Override providers in container | Profile.TEST with fake adapters |
+
+## File Structure
+
+```
+from-dependency-injector/
+├── README.md              # This file
+├── before/                # dependency-injector approach
+│   ├── pyproject.toml
+│   ├── app/
+│   │   ├── ports.py       # Same interfaces
+│   │   ├── services.py    # Service with @inject
+│   │   ├── adapters.py    # Implementations
+│   │   ├── container.py   # Explicit container config
+│   │   └── main.py        # Application entry
+│   └── tests/
+│       └── test_services.py
+└── after/                 # dioxide approach
+    ├── pyproject.toml
+    ├── app/
+    │   ├── ports.py       # Protocol definitions
+    │   ├── services.py    # @service decorator
+    │   ├── adapters.py    # @adapter.for_() decorators
+    │   └── main.py        # Simplified entry
+    └── tests/
+        └── test_services.py
+```
+
+## Migration Steps
+
+### Step 1: Convert Interfaces to Protocols
+
+**Before (ABC-based):**
+```python
+from abc import ABC, abstractmethod
+
+class UserRepository(ABC):
+    @abstractmethod
+    async def get(self, user_id: str) -> dict | None:
+        pass
+```
+
+**After (Protocol-based):**
+```python
+from typing import Protocol
+
+class UserRepositoryPort(Protocol):
+    async def get(self, user_id: str) -> dict | None:
+        ...
+```
+
+### Step 2: Convert Providers to Decorators
+
+**Before (dependency-injector):**
+```python
+from dependency_injector import containers, providers
+
+class Container(containers.DeclarativeContainer):
+    config = providers.Configuration()
+
+    user_repository = providers.Singleton(
+        PostgresUserRepository,
+        connection_string=config.database.url,
+    )
+
+    user_service = providers.Factory(
+        UserService,
+        repository=user_repository,
+    )
+```
+
+**After (dioxide):**
+```python
+from dioxide import adapter, service, Profile
+
+@adapter.for_(UserRepositoryPort, profile=Profile.PRODUCTION)
+class PostgresUserRepository:
+    def __init__(self, connection_string: str):
+        self.connection_string = connection_string
+
+@service
+class UserService:
+    def __init__(self, repository: UserRepositoryPort):
+        self.repository = repository
+```
+
+### Step 3: Convert Test Overrides to Profiles
+
+**Before (dependency-injector):**
+```python
+def test_user_service():
+    container = Container()
+    container.user_repository.override(providers.Singleton(FakeUserRepository))
+
+    service = container.user_service()
+    # test...
+```
+
+**After (dioxide):**
+```python
+@adapter.for_(UserRepositoryPort, profile=Profile.TEST)
+class FakeUserRepository:
+    def __init__(self):
+        self.users = {}
+
+def test_user_service(container):
+    # FakeUserRepository automatically used with Profile.TEST
+    service = container.resolve(UserService)
+    # test...
+```
+
+### Step 4: Remove @inject Decorators
+
+**Before (dependency-injector):**
+```python
+from dependency_injector.wiring import inject, Provide
+
+@inject
+async def get_user_endpoint(
+    user_id: str,
+    service: UserService = Provide[Container.user_service],
+):
+    return await service.get_user(user_id)
+```
+
+**After (dioxide):**
+```python
+async def get_user_endpoint(user_id: str, service: UserService):
+    # Service resolved by framework integration (FastAPI, Flask, etc.)
+    return await service.get_user(user_id)
+```
+
+## Running the Examples
+
+### Before (dependency-injector)
+```bash
+cd before
+pip install -e .
+python -m app.main
+```
+
+### After (dioxide)
+```bash
+cd after
+pip install -e .
+python -m app.main
+```
+
+## Benefits of Migration
+
+1. **Less Boilerplate**: No explicit container configuration
+2. **Type Safety**: Protocol-based ports work with mypy
+3. **Built-in Profiles**: No manual container overrides for testing
+4. **Simpler Testing**: Fakes are just adapters with `Profile.TEST`
+5. **No Wiring**: Dependencies resolved automatically from type hints
+6. **Performance**: Rust-backed container for O(1) resolution
+
+## Common Gotchas
+
+1. **Singleton vs Factory**: dioxide defaults to `Scope.SINGLETON`. Use `scope=Scope.FACTORY`
+   for per-request instances.
+
+2. **Configuration**: dioxide doesn't handle config injection. Use Pydantic Settings
+   or environment variables.
+
+3. **Provider Overrides**: Replace with profile-based adapters. There's no runtime override.
+
+4. **Wiring**: Remove all `@inject` decorators and `Provide[...]` defaults.

--- a/examples/migrations/from-dependency-injector/after/app/__init__.py
+++ b/examples/migrations/from-dependency-injector/after/app/__init__.py
@@ -1,0 +1,1 @@
+"""Example app using dioxide after migration from dependency-injector."""

--- a/examples/migrations/from-dependency-injector/after/app/adapters.py
+++ b/examples/migrations/from-dependency-injector/after/app/adapters.py
@@ -1,0 +1,149 @@
+"""Adapter implementations using dioxide decorators.
+
+The @adapter.for_() decorator replaces dependency-injector's providers.Singleton/Factory.
+Profile-based registration replaces manual container overrides.
+"""
+
+import os
+
+from dioxide import Profile, adapter
+
+from app.ports import CachePort, EmailPort, UserRepositoryPort
+
+
+@adapter.for_(UserRepositoryPort, profile=Profile.PRODUCTION)
+class PostgresUserRepository:
+    """PostgreSQL implementation of UserRepositoryPort.
+
+    Configuration comes from environment variables, not container config.
+    This follows 12-Factor App principles.
+    """
+
+    def __init__(self) -> None:
+        self.connection_string = os.environ.get(
+            "DATABASE_URL", "postgresql://localhost/mydb"
+        )
+        self._users: dict[str, dict] = {}
+        self._next_id = 1
+
+    async def get(self, user_id: str) -> dict | None:
+        return self._users.get(user_id)
+
+    async def save(self, user: dict) -> dict:
+        if "id" not in user:
+            user["id"] = str(self._next_id)
+            self._next_id += 1
+        self._users[user["id"]] = user
+        return user
+
+    async def delete(self, user_id: str) -> bool:
+        if user_id in self._users:
+            del self._users[user_id]
+            return True
+        return False
+
+
+@adapter.for_(EmailPort, profile=Profile.PRODUCTION)
+class SendGridEmailAdapter:
+    """SendGrid implementation of EmailPort."""
+
+    def __init__(self) -> None:
+        self.api_key = os.environ.get("SENDGRID_API_KEY", "")
+
+    async def send(self, to: str, subject: str, body: str) -> bool:
+        print(f"[SendGrid] Sending email to {to}: {subject}")
+        return True
+
+
+@adapter.for_(CachePort, profile=Profile.PRODUCTION)
+class RedisCacheAdapter:
+    """Redis implementation of CachePort."""
+
+    def __init__(self) -> None:
+        self.redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
+        self._cache: dict[str, str] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self._cache.get(key)
+
+    async def set(self, key: str, value: str, ttl: int = 300) -> None:
+        self._cache[key] = value
+
+    async def delete(self, key: str) -> None:
+        self._cache.pop(key, None)
+
+
+@adapter.for_(UserRepositoryPort, profile=Profile.TEST)
+class FakeUserRepository:
+    """In-memory fake for testing.
+
+    With dioxide, test fakes are just adapters with Profile.TEST.
+    No container overrides needed.
+    """
+
+    def __init__(self) -> None:
+        self._users: dict[str, dict] = {}
+        self._next_id = 1
+
+    async def get(self, user_id: str) -> dict | None:
+        return self._users.get(user_id)
+
+    async def save(self, user: dict) -> dict:
+        if "id" not in user:
+            user["id"] = str(self._next_id)
+            self._next_id += 1
+        self._users[user["id"]] = user
+        return user
+
+    async def delete(self, user_id: str) -> bool:
+        if user_id in self._users:
+            del self._users[user_id]
+            return True
+        return False
+
+    def seed(self, *users: dict) -> None:
+        """Seed with test data."""
+        for user in users:
+            self._users[user["id"]] = user
+
+    def clear(self) -> None:
+        """Clear all users."""
+        self._users.clear()
+        self._next_id = 1
+
+
+@adapter.for_(EmailPort, profile=Profile.TEST)
+class FakeEmailAdapter:
+    """In-memory fake for testing."""
+
+    def __init__(self) -> None:
+        self.sent_emails: list[dict] = []
+
+    async def send(self, to: str, subject: str, body: str) -> bool:
+        self.sent_emails.append({"to": to, "subject": subject, "body": body})
+        return True
+
+    def clear(self) -> None:
+        """Clear sent emails."""
+        self.sent_emails.clear()
+
+
+@adapter.for_(CachePort, profile=Profile.TEST)
+class FakeCacheAdapter:
+    """In-memory fake for testing."""
+
+    def __init__(self) -> None:
+        self._cache: dict[str, str] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self._cache.get(key)
+
+    async def set(self, key: str, value: str, ttl: int = 300) -> None:
+        self._cache[key] = value
+
+    async def delete(self, key: str) -> None:
+        self._cache.pop(key, None)
+
+    def clear(self) -> None:
+        """Clear all cache entries."""
+        self._cache.clear()

--- a/examples/migrations/from-dependency-injector/after/app/main.py
+++ b/examples/migrations/from-dependency-injector/after/app/main.py
@@ -1,0 +1,43 @@
+"""Application entry point using dioxide.
+
+Notice there's no container.py file - dioxide uses decorators and scanning
+instead of explicit provider configuration.
+"""
+
+import asyncio
+
+from dioxide import Container, Profile
+
+from app.services import UserService
+
+
+async def main() -> None:
+    """Run the application.
+
+    Configuration comes from environment variables (12-Factor App),
+    not from container config dictionaries.
+    """
+    container = Container()
+    container.scan("app", profile=Profile.PRODUCTION)
+
+    service = container.resolve(UserService)
+
+    print("Creating user...")
+    user = await service.create_user("Alice", "alice@example.com")
+    print(f"Created user: {user}")
+
+    print("\nFetching user (should hit database)...")
+    fetched = await service.get_user(user["id"])
+    print(f"Fetched user: {fetched}")
+
+    print("\nFetching user again (should hit cache)...")
+    cached = await service.get_user(user["id"])
+    print(f"Cached user: {cached}")
+
+    print("\nDeleting user...")
+    deleted = await service.delete_user(user["id"])
+    print(f"Deleted: {deleted}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/migrations/from-dependency-injector/after/app/ports.py
+++ b/examples/migrations/from-dependency-injector/after/app/ports.py
@@ -1,0 +1,51 @@
+"""Port definitions using Protocol (dioxide style).
+
+dioxide uses Protocol-based interfaces which work better with type checkers
+and don't require inheritance from ABC.
+"""
+
+from typing import Protocol
+
+
+class UserRepositoryPort(Protocol):
+    """Port for user persistence.
+
+    Protocols define the interface contract without requiring inheritance.
+    Type checkers verify that adapters implement all methods.
+    """
+
+    async def get(self, user_id: str) -> dict | None:
+        """Get a user by ID."""
+        ...
+
+    async def save(self, user: dict) -> dict:
+        """Save a user and return the saved user."""
+        ...
+
+    async def delete(self, user_id: str) -> bool:
+        """Delete a user by ID."""
+        ...
+
+
+class EmailPort(Protocol):
+    """Port for email sending."""
+
+    async def send(self, to: str, subject: str, body: str) -> bool:
+        """Send an email."""
+        ...
+
+
+class CachePort(Protocol):
+    """Port for caching."""
+
+    async def get(self, key: str) -> str | None:
+        """Get a value from cache."""
+        ...
+
+    async def set(self, key: str, value: str, ttl: int = 300) -> None:
+        """Set a value in cache with TTL."""
+        ...
+
+    async def delete(self, key: str) -> None:
+        """Delete a value from cache."""
+        ...

--- a/examples/migrations/from-dependency-injector/after/app/services.py
+++ b/examples/migrations/from-dependency-injector/after/app/services.py
@@ -1,0 +1,62 @@
+"""Business logic services using dioxide @service decorator.
+
+The @service decorator replaces dependency-injector's provider wiring.
+Dependencies are resolved automatically from type hints.
+"""
+
+from dioxide import service
+
+from app.ports import CachePort, EmailPort, UserRepositoryPort
+
+
+@service
+class UserService:
+    """User management service.
+
+    With dioxide, the @service decorator marks this as injectable.
+    Dependencies are inferred from the constructor's type hints.
+
+    No @inject decorator needed - just use type hints.
+    """
+
+    def __init__(
+        self,
+        repository: UserRepositoryPort,
+        email: EmailPort,
+        cache: CachePort,
+    ) -> None:
+        self._repository = repository
+        self._email = email
+        self._cache = cache
+
+    async def get_user(self, user_id: str) -> dict | None:
+        """Get a user, checking cache first."""
+        cached = await self._cache.get(f"user:{user_id}")
+        if cached:
+            import json
+
+            return json.loads(cached)
+
+        user = await self._repository.get(user_id)
+        if user:
+            import json
+
+            await self._cache.set(f"user:{user_id}", json.dumps(user))
+        return user
+
+    async def create_user(self, name: str, email: str) -> dict:
+        """Create a new user and send welcome email."""
+        user = await self._repository.save({"name": name, "email": email})
+        await self._email.send(
+            to=email,
+            subject="Welcome!",
+            body=f"Hello {name}, welcome to our platform!",
+        )
+        return user
+
+    async def delete_user(self, user_id: str) -> bool:
+        """Delete a user and invalidate cache."""
+        result = await self._repository.delete(user_id)
+        if result:
+            await self._cache.delete(f"user:{user_id}")
+        return result

--- a/examples/migrations/from-dependency-injector/after/pyproject.toml
+++ b/examples/migrations/from-dependency-injector/after/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "di-migration-after"
+version = "0.1.0"
+description = "Example using dioxide (after migration)"
+requires-python = ">=3.11"
+dependencies = [
+    "dioxide>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+python_classes = ["Describe*", "Test*"]
+python_files = ["test_*.py"]
+python_functions = ["it_*", "test_*"]

--- a/examples/migrations/from-dependency-injector/after/tests/__init__.py
+++ b/examples/migrations/from-dependency-injector/after/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for dioxide migration example."""

--- a/examples/migrations/from-dependency-injector/after/tests/conftest.py
+++ b/examples/migrations/from-dependency-injector/after/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Pytest fixtures for dioxide tests.
+
+With dioxide, testing is simpler:
+1. Create a container with Profile.TEST
+2. Scan the app package
+3. Resolve services - fakes are used automatically
+"""
+
+import pytest
+
+from dioxide import Container, Profile
+
+
+@pytest.fixture
+def container() -> Container:
+    """Create a fresh container with test profile.
+
+    No provider overrides needed - Profile.TEST automatically
+    selects the fake adapters.
+    """
+    c = Container()
+    c.scan("app", profile=Profile.TEST)
+    return c

--- a/examples/migrations/from-dependency-injector/after/tests/test_services.py
+++ b/examples/migrations/from-dependency-injector/after/tests/test_services.py
@@ -1,0 +1,99 @@
+"""Tests using dioxide's profile-based testing.
+
+Notice the simplification compared to dependency-injector:
+- No provider overrides
+- No container configuration
+- Just resolve and test
+"""
+
+from dioxide import Container
+
+from app.ports import CachePort, EmailPort, UserRepositoryPort
+from app.services import UserService
+
+
+class DescribeUserService:
+    """Tests for UserService."""
+
+    class DescribeCreateUser:
+        """Tests for create_user method."""
+
+        async def it_creates_user_and_sends_welcome_email(
+            self, container: Container
+        ) -> None:
+            service = container.resolve(UserService)
+            fake_email = container.resolve(EmailPort)
+
+            user = await service.create_user("Alice", "alice@example.com")
+
+            assert user["name"] == "Alice"
+            assert user["email"] == "alice@example.com"
+            assert "id" in user
+
+            assert len(fake_email.sent_emails) == 1
+            assert fake_email.sent_emails[0]["to"] == "alice@example.com"
+            assert "Welcome" in fake_email.sent_emails[0]["subject"]
+
+    class DescribeGetUser:
+        """Tests for get_user method."""
+
+        async def it_returns_user_from_repository(self, container: Container) -> None:
+            service = container.resolve(UserService)
+            fake_repo = container.resolve(UserRepositoryPort)
+
+            fake_repo.seed({"id": "1", "name": "Bob", "email": "bob@example.com"})
+
+            user = await service.get_user("1")
+
+            assert user is not None
+            assert user["name"] == "Bob"
+
+        async def it_returns_none_for_nonexistent_user(
+            self, container: Container
+        ) -> None:
+            service = container.resolve(UserService)
+
+            user = await service.get_user("nonexistent")
+
+            assert user is None
+
+        async def it_caches_user_after_first_fetch(self, container: Container) -> None:
+            service = container.resolve(UserService)
+            fake_repo = container.resolve(UserRepositoryPort)
+            fake_cache = container.resolve(CachePort)
+
+            fake_repo.seed({"id": "1", "name": "Carol", "email": "carol@example.com"})
+
+            await service.get_user("1")
+            cached_value = await fake_cache.get("user:1")
+
+            assert cached_value is not None
+            assert "Carol" in cached_value
+
+    class DescribeDeleteUser:
+        """Tests for delete_user method."""
+
+        async def it_deletes_user_and_invalidates_cache(
+            self, container: Container
+        ) -> None:
+            service = container.resolve(UserService)
+            fake_repo = container.resolve(UserRepositoryPort)
+            fake_cache = container.resolve(CachePort)
+
+            fake_repo.seed({"id": "1", "name": "Dave", "email": "dave@example.com"})
+            await fake_cache.set("user:1", '{"id": "1", "name": "Dave"}')
+
+            result = await service.delete_user("1")
+
+            assert result is True
+            assert await fake_repo.get("1") is None
+            assert await fake_cache.get("user:1") is None
+
+        async def it_returns_false_for_nonexistent_user(
+            self, container: Container
+        ) -> None:
+            service = container.resolve(UserService)
+
+            result = await service.delete_user("nonexistent")
+
+            assert result is False

--- a/examples/migrations/from-dependency-injector/before/app/__init__.py
+++ b/examples/migrations/from-dependency-injector/before/app/__init__.py
@@ -1,0 +1,1 @@
+"""Example app using dependency-injector."""

--- a/examples/migrations/from-dependency-injector/before/app/adapters.py
+++ b/examples/migrations/from-dependency-injector/before/app/adapters.py
@@ -1,0 +1,112 @@
+"""Adapter implementations for dependency-injector example."""
+
+from app.ports import CacheService, EmailService, UserRepository
+
+
+class PostgresUserRepository(UserRepository):
+    """PostgreSQL implementation of UserRepository."""
+
+    def __init__(self, connection_string: str) -> None:
+        self.connection_string = connection_string
+        self._users: dict[str, dict] = {}
+        self._next_id = 1
+
+    async def get(self, user_id: str) -> dict | None:
+        return self._users.get(user_id)
+
+    async def save(self, user: dict) -> dict:
+        if "id" not in user:
+            user["id"] = str(self._next_id)
+            self._next_id += 1
+        self._users[user["id"]] = user
+        return user
+
+    async def delete(self, user_id: str) -> bool:
+        if user_id in self._users:
+            del self._users[user_id]
+            return True
+        return False
+
+
+class SendGridEmailService(EmailService):
+    """SendGrid implementation of EmailService."""
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    async def send(self, to: str, subject: str, body: str) -> bool:
+        print(f"[SendGrid] Sending email to {to}: {subject}")
+        return True
+
+
+class RedisCacheService(CacheService):
+    """Redis implementation of CacheService."""
+
+    def __init__(self, redis_url: str) -> None:
+        self.redis_url = redis_url
+        self._cache: dict[str, str] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self._cache.get(key)
+
+    async def set(self, key: str, value: str, ttl: int = 300) -> None:
+        self._cache[key] = value
+
+    async def delete(self, key: str) -> None:
+        self._cache.pop(key, None)
+
+
+class FakeUserRepository(UserRepository):
+    """In-memory fake for testing."""
+
+    def __init__(self) -> None:
+        self._users: dict[str, dict] = {}
+        self._next_id = 1
+
+    async def get(self, user_id: str) -> dict | None:
+        return self._users.get(user_id)
+
+    async def save(self, user: dict) -> dict:
+        if "id" not in user:
+            user["id"] = str(self._next_id)
+            self._next_id += 1
+        self._users[user["id"]] = user
+        return user
+
+    async def delete(self, user_id: str) -> bool:
+        if user_id in self._users:
+            del self._users[user_id]
+            return True
+        return False
+
+    def seed(self, *users: dict) -> None:
+        """Seed with test data."""
+        for user in users:
+            self._users[user["id"]] = user
+
+
+class FakeEmailService(EmailService):
+    """In-memory fake for testing."""
+
+    def __init__(self) -> None:
+        self.sent_emails: list[dict] = []
+
+    async def send(self, to: str, subject: str, body: str) -> bool:
+        self.sent_emails.append({"to": to, "subject": subject, "body": body})
+        return True
+
+
+class FakeCacheService(CacheService):
+    """In-memory fake for testing."""
+
+    def __init__(self) -> None:
+        self._cache: dict[str, str] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self._cache.get(key)
+
+    async def set(self, key: str, value: str, ttl: int = 300) -> None:
+        self._cache[key] = value
+
+    async def delete(self, key: str) -> None:
+        self._cache.pop(key, None)

--- a/examples/migrations/from-dependency-injector/before/app/container.py
+++ b/examples/migrations/from-dependency-injector/before/app/container.py
@@ -1,0 +1,48 @@
+"""Explicit container configuration for dependency-injector.
+
+This is the verbose part that dioxide eliminates with decorators.
+"""
+
+from dependency_injector import containers, providers
+
+from app.adapters import (
+    PostgresUserRepository,
+    RedisCacheService,
+    SendGridEmailService,
+)
+from app.services import UserService
+
+
+class Container(containers.DeclarativeContainer):
+    """Application container with explicit provider configuration.
+
+    In dependency-injector, you must:
+    1. Define a Configuration provider for settings
+    2. Create providers for each adapter (Singleton/Factory)
+    3. Wire dependencies explicitly
+    4. Override providers for testing
+    """
+
+    config = providers.Configuration()
+
+    user_repository = providers.Singleton(
+        PostgresUserRepository,
+        connection_string=config.database.url,
+    )
+
+    email_service = providers.Singleton(
+        SendGridEmailService,
+        api_key=config.email.api_key,
+    )
+
+    cache_service = providers.Singleton(
+        RedisCacheService,
+        redis_url=config.cache.redis_url,
+    )
+
+    user_service = providers.Factory(
+        UserService,
+        repository=user_repository,
+        email=email_service,
+        cache=cache_service,
+    )

--- a/examples/migrations/from-dependency-injector/before/app/main.py
+++ b/examples/migrations/from-dependency-injector/before/app/main.py
@@ -1,0 +1,39 @@
+"""Application entry point using dependency-injector."""
+
+import asyncio
+
+from app.container import Container
+
+
+async def main() -> None:
+    """Run the application."""
+    container = Container()
+    container.config.from_dict(
+        {
+            "database": {"url": "postgresql://localhost/mydb"},
+            "email": {"api_key": "sg_test_key"},
+            "cache": {"redis_url": "redis://localhost:6379"},
+        }
+    )
+
+    service = container.user_service()
+
+    print("Creating user...")
+    user = await service.create_user("Alice", "alice@example.com")
+    print(f"Created user: {user}")
+
+    print("\nFetching user (should hit database)...")
+    fetched = await service.get_user(user["id"])
+    print(f"Fetched user: {fetched}")
+
+    print("\nFetching user again (should hit cache)...")
+    cached = await service.get_user(user["id"])
+    print(f"Cached user: {cached}")
+
+    print("\nDeleting user...")
+    deleted = await service.delete_user(user["id"])
+    print(f"Deleted: {deleted}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/migrations/from-dependency-injector/before/app/ports.py
+++ b/examples/migrations/from-dependency-injector/before/app/ports.py
@@ -1,0 +1,53 @@
+"""Port definitions using ABC (dependency-injector style).
+
+dependency-injector typically uses ABC-based interfaces.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class UserRepository(ABC):
+    """Abstract base class for user persistence."""
+
+    @abstractmethod
+    async def get(self, user_id: str) -> dict | None:
+        """Get a user by ID."""
+        pass
+
+    @abstractmethod
+    async def save(self, user: dict) -> dict:
+        """Save a user and return the saved user."""
+        pass
+
+    @abstractmethod
+    async def delete(self, user_id: str) -> bool:
+        """Delete a user by ID."""
+        pass
+
+
+class EmailService(ABC):
+    """Abstract base class for email sending."""
+
+    @abstractmethod
+    async def send(self, to: str, subject: str, body: str) -> bool:
+        """Send an email."""
+        pass
+
+
+class CacheService(ABC):
+    """Abstract base class for caching."""
+
+    @abstractmethod
+    async def get(self, key: str) -> str | None:
+        """Get a value from cache."""
+        pass
+
+    @abstractmethod
+    async def set(self, key: str, value: str, ttl: int = 300) -> None:
+        """Set a value in cache with TTL."""
+        pass
+
+    @abstractmethod
+    async def delete(self, key: str) -> None:
+        """Delete a value from cache."""
+        pass

--- a/examples/migrations/from-dependency-injector/before/app/services.py
+++ b/examples/migrations/from-dependency-injector/before/app/services.py
@@ -1,0 +1,53 @@
+"""Business logic services using dependency-injector patterns."""
+
+from app.ports import CacheService, EmailService, UserRepository
+
+
+class UserService:
+    """User management service.
+
+    In dependency-injector, services receive dependencies via constructor.
+    The container wires these using providers.
+    """
+
+    def __init__(
+        self,
+        repository: UserRepository,
+        email: EmailService,
+        cache: CacheService,
+    ) -> None:
+        self._repository = repository
+        self._email = email
+        self._cache = cache
+
+    async def get_user(self, user_id: str) -> dict | None:
+        """Get a user, checking cache first."""
+        cached = await self._cache.get(f"user:{user_id}")
+        if cached:
+            import json
+
+            return json.loads(cached)
+
+        user = await self._repository.get(user_id)
+        if user:
+            import json
+
+            await self._cache.set(f"user:{user_id}", json.dumps(user))
+        return user
+
+    async def create_user(self, name: str, email: str) -> dict:
+        """Create a new user and send welcome email."""
+        user = await self._repository.save({"name": name, "email": email})
+        await self._email.send(
+            to=email,
+            subject="Welcome!",
+            body=f"Hello {name}, welcome to our platform!",
+        )
+        return user
+
+    async def delete_user(self, user_id: str) -> bool:
+        """Delete a user and invalidate cache."""
+        result = await self._repository.delete(user_id)
+        if result:
+            await self._cache.delete(f"user:{user_id}")
+        return result

--- a/examples/migrations/from-dependency-injector/before/pyproject.toml
+++ b/examples/migrations/from-dependency-injector/before/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "di-migration-before"
+version = "0.1.0"
+description = "Example using dependency-injector (before migration)"
+requires-python = ">=3.11"
+dependencies = [
+    "dependency-injector>=4.41.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/examples/migrations/from-dependency-injector/before/tests/__init__.py
+++ b/examples/migrations/from-dependency-injector/before/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for dependency-injector example."""

--- a/examples/migrations/from-dependency-injector/before/tests/test_services.py
+++ b/examples/migrations/from-dependency-injector/before/tests/test_services.py
@@ -1,0 +1,112 @@
+"""Tests using dependency-injector's override pattern.
+
+With dependency-injector, testing requires:
+1. Creating the production container
+2. Overriding providers with fakes
+3. Getting the service from the container
+"""
+
+import pytest
+from dependency_injector import providers
+
+from app.adapters import FakeCacheService, FakeEmailService, FakeUserRepository
+from app.container import Container
+
+
+@pytest.fixture
+def container() -> Container:
+    """Create container with fake implementations."""
+    container = Container()
+
+    container.user_repository.override(providers.Singleton(FakeUserRepository))
+    container.email_service.override(providers.Singleton(FakeEmailService))
+    container.cache_service.override(providers.Singleton(FakeCacheService))
+
+    return container
+
+
+class DescribeUserService:
+    """Tests for UserService."""
+
+    class DescribeCreateUser:
+        """Tests for create_user method."""
+
+        async def it_creates_user_and_sends_welcome_email(
+            self, container: Container
+        ) -> None:
+            service = container.user_service()
+            fake_email = container.email_service()
+
+            user = await service.create_user("Alice", "alice@example.com")
+
+            assert user["name"] == "Alice"
+            assert user["email"] == "alice@example.com"
+            assert "id" in user
+
+            assert len(fake_email.sent_emails) == 1
+            assert fake_email.sent_emails[0]["to"] == "alice@example.com"
+            assert "Welcome" in fake_email.sent_emails[0]["subject"]
+
+    class DescribeGetUser:
+        """Tests for get_user method."""
+
+        async def it_returns_user_from_repository(self, container: Container) -> None:
+            service = container.user_service()
+            fake_repo = container.user_repository()
+
+            fake_repo.seed({"id": "1", "name": "Bob", "email": "bob@example.com"})
+
+            user = await service.get_user("1")
+
+            assert user is not None
+            assert user["name"] == "Bob"
+
+        async def it_returns_none_for_nonexistent_user(
+            self, container: Container
+        ) -> None:
+            service = container.user_service()
+
+            user = await service.get_user("nonexistent")
+
+            assert user is None
+
+        async def it_caches_user_after_first_fetch(self, container: Container) -> None:
+            service = container.user_service()
+            fake_repo = container.user_repository()
+            fake_cache = container.cache_service()
+
+            fake_repo.seed({"id": "1", "name": "Carol", "email": "carol@example.com"})
+
+            await service.get_user("1")
+            cached_value = await fake_cache.get("user:1")
+
+            assert cached_value is not None
+            assert "Carol" in cached_value
+
+    class DescribeDeleteUser:
+        """Tests for delete_user method."""
+
+        async def it_deletes_user_and_invalidates_cache(
+            self, container: Container
+        ) -> None:
+            service = container.user_service()
+            fake_repo = container.user_repository()
+            fake_cache = container.cache_service()
+
+            fake_repo.seed({"id": "1", "name": "Dave", "email": "dave@example.com"})
+            await fake_cache.set("user:1", '{"id": "1", "name": "Dave"}')
+
+            result = await service.delete_user("1")
+
+            assert result is True
+            assert await fake_repo.get("1") is None
+            assert await fake_cache.get("user:1") is None
+
+        async def it_returns_false_for_nonexistent_user(
+            self, container: Container
+        ) -> None:
+            service = container.user_service()
+
+            result = await service.delete_user("nonexistent")
+
+            assert result is False

--- a/examples/migrations/from-injector/README.md
+++ b/examples/migrations/from-injector/README.md
@@ -1,0 +1,212 @@
+# Migration from injector to dioxide
+
+This example demonstrates how to migrate from the `injector` library to dioxide,
+showing the key pattern differences and simplifications.
+
+## Overview
+
+`injector` is a Python dependency injection framework inspired by Guice (Java).
+It uses `Module` classes with `Binder` configuration and `@inject` decorators.
+dioxide replaces this with decorator-based registration and profile-based selection.
+
+## Key Differences
+
+| Aspect | injector | dioxide |
+|--------|----------|---------|
+| **Container** | `Injector` with `Module` classes | `Container` with `scan()` |
+| **Registration** | `Binder.bind()` in modules | `@adapter.for_()` decorators |
+| **Injection** | `@inject` decorator required | Automatic from type hints |
+| **Scoping** | `@singleton` decorator | `scope=Scope.SINGLETON/FACTORY` |
+| **Profiles** | Manual module composition | Built-in `Profile` enum |
+| **Interface binding** | `binder.bind(Interface, to=Impl)` | `@adapter.for_(Port, profile=...)` |
+
+## File Structure
+
+```
+from-injector/
+├── README.md              # This file
+├── before/                # injector approach
+│   ├── pyproject.toml
+│   ├── app/
+│   │   ├── ports.py       # ABC-based interfaces
+│   │   ├── services.py    # Services with @inject
+│   │   ├── adapters.py    # Implementations
+│   │   ├── modules.py     # Binder configuration
+│   │   └── main.py        # Application entry
+│   └── tests/
+│       └── test_services.py
+└── after/                 # dioxide approach
+    ├── pyproject.toml
+    ├── app/
+    │   ├── ports.py       # Protocol definitions
+    │   ├── services.py    # @service decorator
+    │   ├── adapters.py    # @adapter.for_() decorators
+    │   └── main.py        # Simplified entry
+    └── tests/
+        └── test_services.py
+```
+
+## Migration Steps
+
+### Step 1: Replace ABC with Protocol
+
+**Before (ABC-based):**
+```python
+from abc import ABC, abstractmethod
+
+class NotificationService(ABC):
+    @abstractmethod
+    def send(self, recipient: str, message: str) -> bool:
+        pass
+```
+
+**After (Protocol-based):**
+```python
+from typing import Protocol
+
+class NotificationPort(Protocol):
+    def send(self, recipient: str, message: str) -> bool:
+        ...
+```
+
+### Step 2: Remove @inject Decorators
+
+**Before (injector):**
+```python
+from injector import inject
+
+class OrderService:
+    @inject
+    def __init__(
+        self,
+        repository: OrderRepository,
+        notifications: NotificationService,
+    ):
+        self.repository = repository
+        self.notifications = notifications
+```
+
+**After (dioxide):**
+```python
+from dioxide import service
+
+@service
+class OrderService:
+    def __init__(
+        self,
+        repository: OrderRepositoryPort,
+        notifications: NotificationPort,
+    ):
+        self.repository = repository
+        self.notifications = notifications
+```
+
+### Step 3: Convert Modules to Decorators
+
+**Before (injector modules):**
+```python
+from injector import Module, Binder, singleton
+
+class ProductionModule(Module):
+    def configure(self, binder: Binder) -> None:
+        binder.bind(OrderRepository, to=PostgresOrderRepository, scope=singleton)
+        binder.bind(NotificationService, to=EmailNotificationService, scope=singleton)
+
+class TestModule(Module):
+    def configure(self, binder: Binder) -> None:
+        binder.bind(OrderRepository, to=FakeOrderRepository, scope=singleton)
+        binder.bind(NotificationService, to=FakeNotificationService, scope=singleton)
+```
+
+**After (dioxide decorators):**
+```python
+from dioxide import adapter, Profile, Scope
+
+@adapter.for_(OrderRepositoryPort, profile=Profile.PRODUCTION, scope=Scope.SINGLETON)
+class PostgresOrderRepository:
+    ...
+
+@adapter.for_(OrderRepositoryPort, profile=Profile.TEST, scope=Scope.SINGLETON)
+class FakeOrderRepository:
+    ...
+
+@adapter.for_(NotificationPort, profile=Profile.PRODUCTION)
+class EmailNotificationAdapter:
+    ...
+
+@adapter.for_(NotificationPort, profile=Profile.TEST)
+class FakeNotificationAdapter:
+    ...
+```
+
+### Step 4: Simplify Container Usage
+
+**Before (injector):**
+```python
+from injector import Injector
+
+# Production
+injector = Injector([ProductionModule()])
+service = injector.get(OrderService)
+
+# Testing
+test_injector = Injector([TestModule()])
+service = test_injector.get(OrderService)
+```
+
+**After (dioxide):**
+```python
+from dioxide import Container, Profile
+
+# Production
+container = Container()
+container.scan("app", profile=Profile.PRODUCTION)
+service = container.resolve(OrderService)
+
+# Testing
+container = Container()
+container.scan("app", profile=Profile.TEST)
+service = container.resolve(OrderService)
+```
+
+## Running the Examples
+
+### Before (injector)
+```bash
+cd before
+pip install -e .
+python -m app.main
+```
+
+### After (dioxide)
+```bash
+cd after
+pip install -e .
+python -m app.main
+```
+
+## Benefits of Migration
+
+1. **No @inject Boilerplate**: Dependencies resolved from type hints alone
+2. **Built-in Profiles**: No need to create separate module classes
+3. **Decorator Registration**: Clear, declarative adapter binding
+4. **Type Safety**: Protocol-based ports work better with mypy
+5. **Simpler Testing**: Profile.TEST selects fakes automatically
+6. **Less Configuration**: No Module classes to write and compose
+
+## Common Gotchas
+
+1. **@singleton Scope**: Replace `@singleton` with `scope=Scope.SINGLETON` in the
+   `@adapter.for_()` decorator. Note: dioxide defaults to SINGLETON.
+
+2. **Module Composition**: injector allows composing multiple modules. With dioxide,
+   use a single scan with the appropriate profile instead.
+
+3. **Provider Functions**: injector supports `@provider` methods in modules. With
+   dioxide, create an adapter class instead or use a factory pattern.
+
+4. **Assisted Injection**: injector supports `@assisted` for partial injection.
+   dioxide doesn't have this - refactor to use factories or configuration objects.
+
+5. **Multi-binding**: injector supports binding lists of implementations. dioxide
+   doesn't support this directly - use a factory that creates the list.

--- a/examples/migrations/from-injector/after/app/__init__.py
+++ b/examples/migrations/from-injector/after/app/__init__.py
@@ -1,0 +1,1 @@
+"""Example app using dioxide after migration from injector."""

--- a/examples/migrations/from-injector/after/app/adapters.py
+++ b/examples/migrations/from-injector/after/app/adapters.py
@@ -1,0 +1,159 @@
+"""Adapter implementations using dioxide decorators.
+
+The @adapter.for_() decorator replaces injector's Module/Binder configuration.
+Profile-based registration replaces separate production/test modules.
+"""
+
+from dioxide import Profile, Scope, adapter
+
+from app.ports import NotificationPort, Order, OrderRepositoryPort, PaymentGatewayPort
+
+
+@adapter.for_(OrderRepositoryPort, profile=Profile.PRODUCTION, scope=Scope.SINGLETON)
+class PostgresOrderRepository:
+    """PostgreSQL implementation of OrderRepositoryPort."""
+
+    def __init__(self) -> None:
+        self._orders: dict[str, Order] = {}
+
+    async def get(self, order_id: str) -> Order | None:
+        return self._orders.get(order_id)
+
+    async def save(self, order: Order) -> Order:
+        self._orders[order.id] = order
+        return order
+
+    async def find_by_customer(self, customer_id: str) -> list[Order]:
+        return [o for o in self._orders.values() if o.customer_id == customer_id]
+
+
+@adapter.for_(NotificationPort, profile=Profile.PRODUCTION, scope=Scope.SINGLETON)
+class EmailNotificationAdapter:
+    """Email-based notification adapter."""
+
+    async def send(self, recipient: str, message: str) -> bool:
+        print(f"[Email] Sending to {recipient}: {message}")
+        return True
+
+
+@adapter.for_(PaymentGatewayPort, profile=Profile.PRODUCTION, scope=Scope.SINGLETON)
+class StripePaymentAdapter:
+    """Stripe implementation of PaymentGatewayPort."""
+
+    async def charge(self, customer_id: str, amount: float) -> dict:
+        print(f"[Stripe] Charging {customer_id} ${amount:.2f}")
+        return {
+            "transaction_id": f"txn_{customer_id}_{int(amount * 100)}",
+            "status": "succeeded",
+            "amount": amount,
+        }
+
+    async def refund(self, transaction_id: str, amount: float) -> dict:
+        print(f"[Stripe] Refunding {transaction_id} ${amount:.2f}")
+        return {
+            "refund_id": f"ref_{transaction_id}",
+            "status": "succeeded",
+            "amount": amount,
+        }
+
+
+@adapter.for_(OrderRepositoryPort, profile=Profile.TEST, scope=Scope.SINGLETON)
+class FakeOrderRepository:
+    """In-memory fake for testing.
+
+    With dioxide, fakes are just adapters with Profile.TEST.
+    No separate TestModule needed.
+    """
+
+    def __init__(self) -> None:
+        self._orders: dict[str, Order] = {}
+        self._next_id = 1
+
+    async def get(self, order_id: str) -> Order | None:
+        return self._orders.get(order_id)
+
+    async def save(self, order: Order) -> Order:
+        if not order.id:
+            order = Order(
+                id=str(self._next_id),
+                customer_id=order.customer_id,
+                items=order.items,
+                total=order.total,
+                status=order.status,
+                created_at=order.created_at,
+            )
+            self._next_id += 1
+        self._orders[order.id] = order
+        return order
+
+    async def find_by_customer(self, customer_id: str) -> list[Order]:
+        return [o for o in self._orders.values() if o.customer_id == customer_id]
+
+    def seed(self, *orders: Order) -> None:
+        """Seed with test data."""
+        for order in orders:
+            self._orders[order.id] = order
+
+    def clear(self) -> None:
+        """Clear all orders."""
+        self._orders.clear()
+        self._next_id = 1
+
+
+@adapter.for_(NotificationPort, profile=Profile.TEST, scope=Scope.SINGLETON)
+class FakeNotificationAdapter:
+    """In-memory fake for testing."""
+
+    def __init__(self) -> None:
+        self.notifications: list[dict] = []
+
+    async def send(self, recipient: str, message: str) -> bool:
+        self.notifications.append({"recipient": recipient, "message": message})
+        return True
+
+    def clear(self) -> None:
+        """Clear all notifications."""
+        self.notifications.clear()
+
+
+@adapter.for_(PaymentGatewayPort, profile=Profile.TEST, scope=Scope.SINGLETON)
+class FakePaymentGateway:
+    """In-memory fake for testing."""
+
+    def __init__(self) -> None:
+        self.charges: list[dict] = []
+        self.refunds: list[dict] = []
+        self.should_fail = False
+
+    async def charge(self, customer_id: str, amount: float) -> dict:
+        if self.should_fail:
+            raise RuntimeError("Payment failed")
+
+        charge = {
+            "transaction_id": f"fake_txn_{len(self.charges) + 1}",
+            "status": "succeeded",
+            "amount": amount,
+            "customer_id": customer_id,
+        }
+        self.charges.append(charge)
+        return charge
+
+    async def refund(self, transaction_id: str, amount: float) -> dict:
+        refund = {
+            "refund_id": f"fake_ref_{len(self.refunds) + 1}",
+            "status": "succeeded",
+            "amount": amount,
+            "transaction_id": transaction_id,
+        }
+        self.refunds.append(refund)
+        return refund
+
+    def fail_next_charge(self) -> None:
+        """Configure next charge to fail."""
+        self.should_fail = True
+
+    def clear(self) -> None:
+        """Clear all charges and refunds."""
+        self.charges.clear()
+        self.refunds.clear()
+        self.should_fail = False

--- a/examples/migrations/from-injector/after/app/main.py
+++ b/examples/migrations/from-injector/after/app/main.py
@@ -1,0 +1,43 @@
+"""Application entry point using dioxide.
+
+Notice there's no modules.py file - dioxide uses decorators and scanning
+instead of Module classes with Binder configuration.
+"""
+
+import asyncio
+
+from dioxide import Container, Profile
+
+from app.services import OrderService
+
+
+async def main() -> None:
+    """Run the application."""
+    container = Container()
+    container.scan("app", profile=Profile.PRODUCTION)
+
+    service = container.resolve(OrderService)
+
+    print("Creating order...")
+    order = await service.create_order(
+        customer_id="cust_123",
+        items=["Widget", "Gadget"],
+        total=99.99,
+    )
+    print(f"Created order: {order}")
+
+    print("\nFetching order...")
+    fetched = await service.get_order(order.id)
+    print(f"Fetched order: {fetched}")
+
+    print("\nGetting customer orders...")
+    orders = await service.get_customer_orders("cust_123")
+    print(f"Customer has {len(orders)} order(s)")
+
+    print("\nCancelling order...")
+    cancelled = await service.cancel_order(order.id)
+    print(f"Cancelled order: {cancelled}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/migrations/from-injector/after/app/ports.py
+++ b/examples/migrations/from-injector/after/app/ports.py
@@ -1,0 +1,59 @@
+"""Port definitions using Protocol (dioxide style).
+
+Protocol-based interfaces are more Pythonic and work better with type checkers.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+
+@dataclass
+class Order:
+    """Order domain model."""
+
+    id: str
+    customer_id: str
+    items: list[str]
+    total: float
+    status: str
+    created_at: datetime
+
+
+class OrderRepositoryPort(Protocol):
+    """Port for order persistence.
+
+    Protocols define the interface contract without requiring inheritance.
+    """
+
+    async def get(self, order_id: str) -> Order | None:
+        """Get an order by ID."""
+        ...
+
+    async def save(self, order: Order) -> Order:
+        """Save an order."""
+        ...
+
+    async def find_by_customer(self, customer_id: str) -> list[Order]:
+        """Find all orders for a customer."""
+        ...
+
+
+class NotificationPort(Protocol):
+    """Port for notifications."""
+
+    async def send(self, recipient: str, message: str) -> bool:
+        """Send a notification."""
+        ...
+
+
+class PaymentGatewayPort(Protocol):
+    """Port for payment processing."""
+
+    async def charge(self, customer_id: str, amount: float) -> dict:
+        """Charge a customer."""
+        ...
+
+    async def refund(self, transaction_id: str, amount: float) -> dict:
+        """Refund a transaction."""
+        ...

--- a/examples/migrations/from-injector/after/app/services.py
+++ b/examples/migrations/from-injector/after/app/services.py
@@ -1,0 +1,95 @@
+"""Business logic services using dioxide @service decorator.
+
+The @service decorator replaces injector's @inject decorator.
+No module configuration needed - dependencies resolved from type hints.
+"""
+
+from datetime import datetime, UTC
+from uuid import uuid4
+
+from dioxide import service
+
+from app.ports import NotificationPort, Order, OrderRepositoryPort, PaymentGatewayPort
+
+
+@service
+class OrderService:
+    """Order management service.
+
+    With dioxide, the @service decorator marks this as injectable.
+    Dependencies are inferred from the constructor's type hints.
+
+    No @inject decorator needed - just use type hints.
+    """
+
+    def __init__(
+        self,
+        repository: OrderRepositoryPort,
+        notifications: NotificationPort,
+        payments: PaymentGatewayPort,
+    ) -> None:
+        self._repository = repository
+        self._notifications = notifications
+        self._payments = payments
+
+    async def create_order(
+        self,
+        customer_id: str,
+        items: list[str],
+        total: float,
+    ) -> Order:
+        """Create a new order and process payment."""
+        payment_result = await self._payments.charge(customer_id, total)
+
+        order = Order(
+            id=str(uuid4()),
+            customer_id=customer_id,
+            items=items,
+            total=total,
+            status="confirmed",
+            created_at=datetime.now(UTC),
+        )
+        order = await self._repository.save(order)
+
+        await self._notifications.send(
+            recipient=customer_id,
+            message=f"Order {order.id} confirmed for ${total:.2f}",
+        )
+
+        return order
+
+    async def get_order(self, order_id: str) -> Order | None:
+        """Get an order by ID."""
+        return await self._repository.get(order_id)
+
+    async def get_customer_orders(self, customer_id: str) -> list[Order]:
+        """Get all orders for a customer."""
+        return await self._repository.find_by_customer(customer_id)
+
+    async def cancel_order(self, order_id: str) -> Order | None:
+        """Cancel an order and process refund."""
+        order = await self._repository.get(order_id)
+        if not order:
+            return None
+
+        if order.status == "cancelled":
+            return order
+
+        await self._payments.refund(f"txn_{order.id}", order.total)
+
+        cancelled_order = Order(
+            id=order.id,
+            customer_id=order.customer_id,
+            items=order.items,
+            total=order.total,
+            status="cancelled",
+            created_at=order.created_at,
+        )
+        await self._repository.save(cancelled_order)
+
+        await self._notifications.send(
+            recipient=order.customer_id,
+            message=f"Order {order.id} has been cancelled. Refund of ${order.total:.2f} initiated.",
+        )
+
+        return cancelled_order

--- a/examples/migrations/from-injector/after/pyproject.toml
+++ b/examples/migrations/from-injector/after/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "injector-migration-after"
+version = "0.1.0"
+description = "Example using dioxide (after migration from injector)"
+requires-python = ">=3.11"
+dependencies = [
+    "dioxide>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+python_classes = ["Describe*", "Test*"]
+python_files = ["test_*.py"]
+python_functions = ["it_*", "test_*"]

--- a/examples/migrations/from-injector/after/tests/__init__.py
+++ b/examples/migrations/from-injector/after/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for dioxide migration example."""

--- a/examples/migrations/from-injector/after/tests/conftest.py
+++ b/examples/migrations/from-injector/after/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Pytest fixtures for dioxide tests.
+
+With dioxide, testing is simpler - no TestModule needed.
+Just create a container with Profile.TEST and scan.
+"""
+
+import pytest
+
+from dioxide import Container, Profile
+
+
+@pytest.fixture
+def container() -> Container:
+    """Create a fresh container with test profile.
+
+    Profile.TEST automatically selects the fake adapters.
+    No module configuration needed.
+    """
+    c = Container()
+    c.scan("app", profile=Profile.TEST)
+    return c

--- a/examples/migrations/from-injector/after/tests/test_services.py
+++ b/examples/migrations/from-injector/after/tests/test_services.py
@@ -1,0 +1,111 @@
+"""Tests using dioxide's profile-based testing.
+
+Notice the simplification compared to injector:
+- No TestModule
+- No Injector setup
+- Just resolve from container and test
+"""
+
+from dioxide import Container
+
+from app.ports import NotificationPort, OrderRepositoryPort, PaymentGatewayPort
+from app.services import OrderService
+
+
+class DescribeOrderService:
+    """Tests for OrderService."""
+
+    class DescribeCreateOrder:
+        """Tests for create_order method."""
+
+        async def it_creates_order_and_sends_notification(
+            self, container: Container
+        ) -> None:
+            service = container.resolve(OrderService)
+            fake_notifications = container.resolve(NotificationPort)
+
+            order = await service.create_order(
+                customer_id="cust_123",
+                items=["Widget"],
+                total=49.99,
+            )
+
+            assert order.customer_id == "cust_123"
+            assert order.items == ["Widget"]
+            assert order.total == 49.99
+            assert order.status == "confirmed"
+
+            assert len(fake_notifications.notifications) == 1
+            assert "cust_123" in fake_notifications.notifications[0]["recipient"]
+
+        async def it_processes_payment(self, container: Container) -> None:
+            service = container.resolve(OrderService)
+            fake_payments = container.resolve(PaymentGatewayPort)
+
+            await service.create_order(
+                customer_id="cust_456",
+                items=["Gadget"],
+                total=29.99,
+            )
+
+            assert len(fake_payments.charges) == 1
+            assert fake_payments.charges[0]["amount"] == 29.99
+            assert fake_payments.charges[0]["customer_id"] == "cust_456"
+
+    class DescribeGetOrder:
+        """Tests for get_order method."""
+
+        async def it_returns_saved_order(self, container: Container) -> None:
+            service = container.resolve(OrderService)
+
+            created = await service.create_order(
+                customer_id="cust_789",
+                items=["Thing"],
+                total=19.99,
+            )
+            fetched = await service.get_order(created.id)
+
+            assert fetched is not None
+            assert fetched.id == created.id
+
+        async def it_returns_none_for_nonexistent_order(
+            self, container: Container
+        ) -> None:
+            service = container.resolve(OrderService)
+
+            result = await service.get_order("nonexistent")
+
+            assert result is None
+
+    class DescribeCancelOrder:
+        """Tests for cancel_order method."""
+
+        async def it_cancels_order_and_refunds(self, container: Container) -> None:
+            service = container.resolve(OrderService)
+            fake_payments = container.resolve(PaymentGatewayPort)
+            fake_notifications = container.resolve(NotificationPort)
+
+            order = await service.create_order(
+                customer_id="cust_cancel",
+                items=["Item"],
+                total=59.99,
+            )
+
+            cancelled = await service.cancel_order(order.id)
+
+            assert cancelled is not None
+            assert cancelled.status == "cancelled"
+            assert len(fake_payments.refunds) == 1
+            assert fake_payments.refunds[0]["amount"] == 59.99
+
+            cancel_notification = fake_notifications.notifications[-1]
+            assert "cancelled" in cancel_notification["message"]
+
+        async def it_returns_none_for_nonexistent_order(
+            self, container: Container
+        ) -> None:
+            service = container.resolve(OrderService)
+
+            result = await service.cancel_order("nonexistent")
+
+            assert result is None

--- a/examples/migrations/from-injector/before/app/__init__.py
+++ b/examples/migrations/from-injector/before/app/__init__.py
@@ -1,0 +1,1 @@
+"""Example app using injector library."""

--- a/examples/migrations/from-injector/before/app/adapters.py
+++ b/examples/migrations/from-injector/before/app/adapters.py
@@ -1,0 +1,130 @@
+"""Adapter implementations for injector example."""
+
+from datetime import datetime, UTC
+
+from app.ports import NotificationService, Order, OrderRepository, PaymentGateway
+
+
+class PostgresOrderRepository(OrderRepository):
+    """PostgreSQL implementation of OrderRepository."""
+
+    def __init__(self) -> None:
+        self._orders: dict[str, Order] = {}
+
+    async def get(self, order_id: str) -> Order | None:
+        return self._orders.get(order_id)
+
+    async def save(self, order: Order) -> Order:
+        self._orders[order.id] = order
+        return order
+
+    async def find_by_customer(self, customer_id: str) -> list[Order]:
+        return [o for o in self._orders.values() if o.customer_id == customer_id]
+
+
+class EmailNotificationService(NotificationService):
+    """Email-based notification service."""
+
+    async def send(self, recipient: str, message: str) -> bool:
+        print(f"[Email] Sending to {recipient}: {message}")
+        return True
+
+
+class StripePaymentGateway(PaymentGateway):
+    """Stripe implementation of PaymentGateway."""
+
+    async def charge(self, customer_id: str, amount: float) -> dict:
+        print(f"[Stripe] Charging {customer_id} ${amount:.2f}")
+        return {
+            "transaction_id": f"txn_{customer_id}_{int(amount * 100)}",
+            "status": "succeeded",
+            "amount": amount,
+        }
+
+    async def refund(self, transaction_id: str, amount: float) -> dict:
+        print(f"[Stripe] Refunding {transaction_id} ${amount:.2f}")
+        return {
+            "refund_id": f"ref_{transaction_id}",
+            "status": "succeeded",
+            "amount": amount,
+        }
+
+
+class FakeOrderRepository(OrderRepository):
+    """In-memory fake for testing."""
+
+    def __init__(self) -> None:
+        self._orders: dict[str, Order] = {}
+        self._next_id = 1
+
+    async def get(self, order_id: str) -> Order | None:
+        return self._orders.get(order_id)
+
+    async def save(self, order: Order) -> Order:
+        if not order.id:
+            order = Order(
+                id=str(self._next_id),
+                customer_id=order.customer_id,
+                items=order.items,
+                total=order.total,
+                status=order.status,
+                created_at=order.created_at,
+            )
+            self._next_id += 1
+        self._orders[order.id] = order
+        return order
+
+    async def find_by_customer(self, customer_id: str) -> list[Order]:
+        return [o for o in self._orders.values() if o.customer_id == customer_id]
+
+    def seed(self, *orders: Order) -> None:
+        """Seed with test data."""
+        for order in orders:
+            self._orders[order.id] = order
+
+
+class FakeNotificationService(NotificationService):
+    """In-memory fake for testing."""
+
+    def __init__(self) -> None:
+        self.notifications: list[dict] = []
+
+    async def send(self, recipient: str, message: str) -> bool:
+        self.notifications.append({"recipient": recipient, "message": message})
+        return True
+
+
+class FakePaymentGateway(PaymentGateway):
+    """In-memory fake for testing."""
+
+    def __init__(self) -> None:
+        self.charges: list[dict] = []
+        self.refunds: list[dict] = []
+        self.should_fail = False
+
+    async def charge(self, customer_id: str, amount: float) -> dict:
+        if self.should_fail:
+            raise RuntimeError("Payment failed")
+
+        charge = {
+            "transaction_id": f"fake_txn_{len(self.charges) + 1}",
+            "status": "succeeded",
+            "amount": amount,
+            "customer_id": customer_id,
+        }
+        self.charges.append(charge)
+        return charge
+
+    async def refund(self, transaction_id: str, amount: float) -> dict:
+        refund = {
+            "refund_id": f"fake_ref_{len(self.refunds) + 1}",
+            "status": "succeeded",
+            "amount": amount,
+            "transaction_id": transaction_id,
+        }
+        self.refunds.append(refund)
+        return refund
+
+    def fail_next_charge(self) -> None:
+        """Configure next charge to fail."""
+        self.should_fail = True

--- a/examples/migrations/from-injector/before/app/main.py
+++ b/examples/migrations/from-injector/before/app/main.py
@@ -1,0 +1,39 @@
+"""Application entry point using injector."""
+
+import asyncio
+
+from injector import Injector
+
+from app.modules import ProductionModule
+from app.services import OrderService
+
+
+async def main() -> None:
+    """Run the application."""
+    injector = Injector([ProductionModule()])
+
+    service = injector.get(OrderService)
+
+    print("Creating order...")
+    order = await service.create_order(
+        customer_id="cust_123",
+        items=["Widget", "Gadget"],
+        total=99.99,
+    )
+    print(f"Created order: {order}")
+
+    print("\nFetching order...")
+    fetched = await service.get_order(order.id)
+    print(f"Fetched order: {fetched}")
+
+    print("\nGetting customer orders...")
+    orders = await service.get_customer_orders("cust_123")
+    print(f"Customer has {len(orders)} order(s)")
+
+    print("\nCancelling order...")
+    cancelled = await service.cancel_order(order.id)
+    print(f"Cancelled order: {cancelled}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/migrations/from-injector/before/app/modules.py
+++ b/examples/migrations/from-injector/before/app/modules.py
@@ -1,0 +1,43 @@
+"""Injector module configuration.
+
+This is the verbose part where you bind interfaces to implementations.
+dioxide replaces this with @adapter.for_() decorators.
+"""
+
+from injector import Binder, Module, singleton
+
+from app.adapters import (
+    EmailNotificationService,
+    FakeNotificationService,
+    FakeOrderRepository,
+    FakePaymentGateway,
+    PostgresOrderRepository,
+    StripePaymentGateway,
+)
+from app.ports import NotificationService, OrderRepository, PaymentGateway
+
+
+class ProductionModule(Module):
+    """Production bindings for real implementations.
+
+    In injector, you create Module classes that configure the Binder.
+    Each binding maps an interface to an implementation.
+    """
+
+    def configure(self, binder: Binder) -> None:
+        binder.bind(OrderRepository, to=PostgresOrderRepository, scope=singleton)
+        binder.bind(NotificationService, to=EmailNotificationService, scope=singleton)
+        binder.bind(PaymentGateway, to=StripePaymentGateway, scope=singleton)
+
+
+class TestModule(Module):
+    """Test bindings for fake implementations.
+
+    For testing, you create a separate module with fake bindings.
+    This requires maintaining parallel module definitions.
+    """
+
+    def configure(self, binder: Binder) -> None:
+        binder.bind(OrderRepository, to=FakeOrderRepository, scope=singleton)
+        binder.bind(NotificationService, to=FakeNotificationService, scope=singleton)
+        binder.bind(PaymentGateway, to=FakePaymentGateway, scope=singleton)

--- a/examples/migrations/from-injector/before/app/ports.py
+++ b/examples/migrations/from-injector/before/app/ports.py
@@ -1,0 +1,62 @@
+"""Port definitions using ABC (injector style).
+
+injector typically uses ABC-based interfaces for dependency binding.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class Order:
+    """Order domain model."""
+
+    id: str
+    customer_id: str
+    items: list[str]
+    total: float
+    status: str
+    created_at: datetime
+
+
+class OrderRepository(ABC):
+    """Abstract base class for order persistence."""
+
+    @abstractmethod
+    async def get(self, order_id: str) -> Order | None:
+        """Get an order by ID."""
+        pass
+
+    @abstractmethod
+    async def save(self, order: Order) -> Order:
+        """Save an order."""
+        pass
+
+    @abstractmethod
+    async def find_by_customer(self, customer_id: str) -> list[Order]:
+        """Find all orders for a customer."""
+        pass
+
+
+class NotificationService(ABC):
+    """Abstract base class for notifications."""
+
+    @abstractmethod
+    async def send(self, recipient: str, message: str) -> bool:
+        """Send a notification."""
+        pass
+
+
+class PaymentGateway(ABC):
+    """Abstract base class for payment processing."""
+
+    @abstractmethod
+    async def charge(self, customer_id: str, amount: float) -> dict:
+        """Charge a customer."""
+        pass
+
+    @abstractmethod
+    async def refund(self, transaction_id: str, amount: float) -> dict:
+        """Refund a transaction."""
+        pass

--- a/examples/migrations/from-injector/before/app/services.py
+++ b/examples/migrations/from-injector/before/app/services.py
@@ -1,0 +1,89 @@
+"""Business logic services using injector's @inject decorator."""
+
+from datetime import datetime, UTC
+from uuid import uuid4
+
+from injector import inject
+
+from app.ports import NotificationService, Order, OrderRepository, PaymentGateway
+
+
+class OrderService:
+    """Order management service.
+
+    In injector, the @inject decorator marks the constructor for injection.
+    The Injector will resolve dependencies based on type hints.
+    """
+
+    @inject
+    def __init__(
+        self,
+        repository: OrderRepository,
+        notifications: NotificationService,
+        payments: PaymentGateway,
+    ) -> None:
+        self._repository = repository
+        self._notifications = notifications
+        self._payments = payments
+
+    async def create_order(
+        self,
+        customer_id: str,
+        items: list[str],
+        total: float,
+    ) -> Order:
+        """Create a new order and process payment."""
+        payment_result = await self._payments.charge(customer_id, total)
+
+        order = Order(
+            id=str(uuid4()),
+            customer_id=customer_id,
+            items=items,
+            total=total,
+            status="confirmed",
+            created_at=datetime.now(UTC),
+        )
+        order = await self._repository.save(order)
+
+        await self._notifications.send(
+            recipient=customer_id,
+            message=f"Order {order.id} confirmed for ${total:.2f}",
+        )
+
+        return order
+
+    async def get_order(self, order_id: str) -> Order | None:
+        """Get an order by ID."""
+        return await self._repository.get(order_id)
+
+    async def get_customer_orders(self, customer_id: str) -> list[Order]:
+        """Get all orders for a customer."""
+        return await self._repository.find_by_customer(customer_id)
+
+    async def cancel_order(self, order_id: str) -> Order | None:
+        """Cancel an order and process refund."""
+        order = await self._repository.get(order_id)
+        if not order:
+            return None
+
+        if order.status == "cancelled":
+            return order
+
+        await self._payments.refund(f"txn_{order.id}", order.total)
+
+        cancelled_order = Order(
+            id=order.id,
+            customer_id=order.customer_id,
+            items=order.items,
+            total=order.total,
+            status="cancelled",
+            created_at=order.created_at,
+        )
+        await self._repository.save(cancelled_order)
+
+        await self._notifications.send(
+            recipient=order.customer_id,
+            message=f"Order {order.id} has been cancelled. Refund of ${order.total:.2f} initiated.",
+        )
+
+        return cancelled_order

--- a/examples/migrations/from-injector/before/pyproject.toml
+++ b/examples/migrations/from-injector/before/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "injector-migration-before"
+version = "0.1.0"
+description = "Example using injector library (before migration)"
+requires-python = ">=3.11"
+dependencies = [
+    "injector>=0.21.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/examples/migrations/from-injector/before/tests/__init__.py
+++ b/examples/migrations/from-injector/before/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for injector example."""

--- a/examples/migrations/from-injector/before/tests/test_services.py
+++ b/examples/migrations/from-injector/before/tests/test_services.py
@@ -1,0 +1,119 @@
+"""Tests using injector's module-based testing pattern.
+
+With injector, testing requires:
+1. Creating an Injector with the TestModule
+2. Getting the service from the injector
+3. Getting fakes to inspect state
+"""
+
+import pytest
+from injector import Injector
+
+from app.modules import TestModule
+from app.ports import NotificationService, OrderRepository, PaymentGateway
+from app.services import OrderService
+
+
+@pytest.fixture
+def injector() -> Injector:
+    """Create injector with test module."""
+    return Injector([TestModule()])
+
+
+class DescribeOrderService:
+    """Tests for OrderService."""
+
+    class DescribeCreateOrder:
+        """Tests for create_order method."""
+
+        async def it_creates_order_and_sends_notification(
+            self, injector: Injector
+        ) -> None:
+            service = injector.get(OrderService)
+            fake_notifications = injector.get(NotificationService)
+
+            order = await service.create_order(
+                customer_id="cust_123",
+                items=["Widget"],
+                total=49.99,
+            )
+
+            assert order.customer_id == "cust_123"
+            assert order.items == ["Widget"]
+            assert order.total == 49.99
+            assert order.status == "confirmed"
+
+            assert len(fake_notifications.notifications) == 1
+            assert "cust_123" in fake_notifications.notifications[0]["recipient"]
+
+        async def it_processes_payment(self, injector: Injector) -> None:
+            service = injector.get(OrderService)
+            fake_payments = injector.get(PaymentGateway)
+
+            await service.create_order(
+                customer_id="cust_456",
+                items=["Gadget"],
+                total=29.99,
+            )
+
+            assert len(fake_payments.charges) == 1
+            assert fake_payments.charges[0]["amount"] == 29.99
+            assert fake_payments.charges[0]["customer_id"] == "cust_456"
+
+    class DescribeGetOrder:
+        """Tests for get_order method."""
+
+        async def it_returns_saved_order(self, injector: Injector) -> None:
+            service = injector.get(OrderService)
+
+            created = await service.create_order(
+                customer_id="cust_789",
+                items=["Thing"],
+                total=19.99,
+            )
+            fetched = await service.get_order(created.id)
+
+            assert fetched is not None
+            assert fetched.id == created.id
+
+        async def it_returns_none_for_nonexistent_order(
+            self, injector: Injector
+        ) -> None:
+            service = injector.get(OrderService)
+
+            result = await service.get_order("nonexistent")
+
+            assert result is None
+
+    class DescribeCancelOrder:
+        """Tests for cancel_order method."""
+
+        async def it_cancels_order_and_refunds(self, injector: Injector) -> None:
+            service = injector.get(OrderService)
+            fake_payments = injector.get(PaymentGateway)
+            fake_notifications = injector.get(NotificationService)
+
+            order = await service.create_order(
+                customer_id="cust_cancel",
+                items=["Item"],
+                total=59.99,
+            )
+
+            cancelled = await service.cancel_order(order.id)
+
+            assert cancelled is not None
+            assert cancelled.status == "cancelled"
+            assert len(fake_payments.refunds) == 1
+            assert fake_payments.refunds[0]["amount"] == 59.99
+
+            cancel_notification = fake_notifications.notifications[-1]
+            assert "cancelled" in cancel_notification["message"]
+
+        async def it_returns_none_for_nonexistent_order(
+            self, injector: Injector
+        ) -> None:
+            service = injector.get(OrderService)
+
+            result = await service.cancel_order("nonexistent")
+
+            assert result is None

--- a/examples/patterns/caching/README.md
+++ b/examples/patterns/caching/README.md
@@ -1,0 +1,199 @@
+# Caching Adapter Pattern Example
+
+This example demonstrates the caching adapter pattern (decorator pattern) with
+dioxide, showing how to wrap a real repository with caching behavior that can
+be swapped out based on profile.
+
+## What This Example Demonstrates
+
+1. **Caching decorator pattern**: Wrap a repository with transparent caching
+2. **Profile-based switching**: Production uses caching, tests use fakes
+3. **Cache invalidation strategies**: TTL and explicit invalidation
+4. **Testing cache behavior**: Verify caching without real Redis
+
+## Architecture Overview
+
+```
+Production Stack:
+    UserService
+        -> CachingUserRepository (caches reads)
+            -> PostgresUserRepository (actual database)
+            -> RedisCache (cache storage)
+
+Test Stack:
+    UserService
+        -> FakeUserRepository (in-memory, no caching)
+```
+
+## The Caching Pattern
+
+The caching adapter wraps another repository and adds caching behavior:
+
+```python
+@adapter.for_(UserRepositoryPort, profile=Profile.PRODUCTION)
+class CachingUserRepository:
+    def __init__(
+        self,
+        delegate: DatabaseUserRepository,  # The "real" repository
+        cache: CachePort,                   # Cache storage
+    ):
+        self.delegate = delegate
+        self.cache = cache
+
+    async def get_by_id(self, user_id: str) -> User | None:
+        # Check cache first
+        cached = await self.cache.get(f"user:{user_id}")
+        if cached:
+            return User(**cached)
+
+        # Cache miss - get from database
+        user = await self.delegate.get_by_id(user_id)
+        if user:
+            await self.cache.set(f"user:{user_id}", user.to_dict())
+
+        return user
+```
+
+## Key Concepts
+
+### 1. The Delegate Pattern
+
+The caching repository delegates to a "real" repository:
+
+```python
+class CachingUserRepository:
+    def __init__(self, delegate: DatabaseUserRepository, cache: CachePort):
+        self.delegate = delegate  # PostgresUserRepository
+        self.cache = cache        # RedisCache
+```
+
+This allows:
+- Transparent caching (callers don't know about it)
+- Easy testing (swap delegate with fake)
+- Clear separation of concerns
+
+### 2. Profile-Based Configuration
+
+```python
+# Production: Uses caching wrapper
+@adapter.for_(UserRepositoryPort, profile=Profile.PRODUCTION)
+class CachingUserRepository:
+    def __init__(self, delegate: DatabaseUserRepository, cache: CachePort):
+        ...
+
+# Test: No caching, just in-memory storage
+@adapter.for_(UserRepositoryPort, profile=Profile.TEST)
+class FakeUserRepository:
+    def __init__(self):
+        self.users = {}
+```
+
+### 3. Cache Invalidation
+
+```python
+async def save(self, user: User) -> None:
+    await self.delegate.save(user)
+    # Invalidate cache on write
+    await self.cache.delete(f"user:{user.id}")
+```
+
+## Running the Example
+
+```bash
+# From the dioxide repository root
+cd examples/patterns/caching
+
+# Run the example
+python -m app.main
+
+# Run tests
+pytest tests/ -v
+```
+
+## Testing Strategies
+
+### Test Cache Hits and Misses
+
+```python
+async def test_caches_user_on_first_read(container, cache):
+    service = container.resolve(UserService)
+
+    # First read - cache miss
+    await service.get_user("user-1")
+    assert cache.miss_count == 1
+
+    # Second read - cache hit
+    await service.get_user("user-1")
+    assert cache.hit_count == 1
+```
+
+### Test Cache Invalidation
+
+```python
+async def test_invalidates_cache_on_update(container, cache):
+    service = container.resolve(UserService)
+
+    # Read to populate cache
+    await service.get_user("user-1")
+    assert "user:user-1" in cache.data
+
+    # Update should invalidate
+    await service.update_user("user-1", name="New Name")
+    assert "user:user-1" not in cache.data
+```
+
+### Test Without Cache (Profile.TEST)
+
+```python
+async def test_works_without_caching(container):
+    # TEST profile uses FakeUserRepository (no caching)
+    service = container.resolve(UserService)
+
+    await service.get_user("user-1")
+    # Works fine, just no caching
+```
+
+## When to Use This Pattern
+
+**Good use cases:**
+- Read-heavy data (user profiles, product catalogs)
+- Data that doesn't change frequently
+- Expensive database queries
+
+**Consider alternatives when:**
+- Data changes frequently (use shorter TTL or skip caching)
+- Consistency is critical (banking, inventory)
+- Data is user-specific (session storage might be better)
+
+## Files Structure
+
+```
+caching/
+├── README.md
+├── pyproject.toml
+├── requirements.txt
+├── app/
+│   ├── __init__.py
+│   ├── main.py
+│   ├── domain/
+│   │   ├── __init__.py
+│   │   ├── models.py
+│   │   ├── ports.py
+│   │   └── services.py
+│   └── adapters/
+│       ├── __init__.py
+│       ├── postgres.py      # DatabaseUserRepository
+│       ├── caching.py       # CachingUserRepository
+│       ├── redis.py         # RedisCache
+│       └── fakes.py         # FakeUserRepository, FakeCache
+└── tests/
+    ├── __init__.py
+    ├── conftest.py
+    └── test_caching.py
+```
+
+## Learn More
+
+- [dioxide Documentation](https://github.com/mikelane/dioxide)
+- [Cache-Aside Pattern](https://docs.microsoft.com/en-us/azure/architecture/patterns/cache-aside)
+- [Decorator Pattern](https://refactoring.guru/design-patterns/decorator)

--- a/examples/patterns/caching/app/__init__.py
+++ b/examples/patterns/caching/app/__init__.py
@@ -1,0 +1,5 @@
+"""Caching adapter pattern example.
+
+This example demonstrates how to implement transparent caching using
+the decorator/wrapper pattern with dioxide.
+"""

--- a/examples/patterns/caching/app/adapters/__init__.py
+++ b/examples/patterns/caching/app/adapters/__init__.py
@@ -1,0 +1,14 @@
+"""Adapters for the caching example."""
+
+from .caching import CachingUserRepository
+from .fakes import FakeCache, FakeUserRepository
+from .postgres import PostgresUserRepository
+from .redis import RedisCache
+
+__all__ = [
+    "PostgresUserRepository",
+    "CachingUserRepository",
+    "RedisCache",
+    "FakeUserRepository",
+    "FakeCache",
+]

--- a/examples/patterns/caching/app/adapters/caching.py
+++ b/examples/patterns/caching/app/adapters/caching.py
@@ -1,0 +1,120 @@
+"""Caching repository adapter - the decorator pattern in action.
+
+This adapter wraps a database repository with caching behavior.
+It implements UserRepositoryPort and delegates to DatabaseUserRepositoryPort.
+"""
+
+from dioxide import Profile, adapter
+
+from ..domain.models import User
+from ..domain.ports import CachePort, DatabaseUserRepositoryPort, UserRepositoryPort
+
+
+@adapter.for_(UserRepositoryPort, profile=Profile.PRODUCTION)
+class CachingUserRepository:
+    """User repository with transparent caching.
+
+    This adapter implements the decorator pattern:
+    - Implements UserRepositoryPort (same interface as delegate)
+    - Wraps DatabaseUserRepositoryPort (the "real" repository)
+    - Adds caching behavior using CachePort
+
+    Cache strategy:
+    - Cache individual users by ID and email
+    - Invalidate on write (save/delete)
+    - TTL-based expiration (default 5 minutes)
+    """
+
+    def __init__(
+        self,
+        delegate: DatabaseUserRepositoryPort,
+        cache: CachePort,
+    ) -> None:
+        """Initialize with delegate repository and cache.
+
+        Args:
+            delegate: The underlying database repository
+            cache: Cache storage for user data
+        """
+        self.delegate = delegate
+        self.cache = cache
+        self._ttl = 300  # 5 minutes
+
+    def _user_key(self, user_id: str) -> str:
+        """Generate cache key for user by ID."""
+        return f"user:id:{user_id}"
+
+    def _email_key(self, email: str) -> str:
+        """Generate cache key for user by email."""
+        return f"user:email:{email}"
+
+    async def get_by_id(self, user_id: str) -> User | None:
+        """Get user by ID with cache-aside pattern.
+
+        1. Check cache for user
+        2. If miss, fetch from database
+        3. If found, cache for future requests
+        """
+        # Check cache first
+        key = self._user_key(user_id)
+        cached = await self.cache.get(key)
+        if cached is not None:
+            return User.from_dict(cached)
+
+        # Cache miss - fetch from database
+        user = await self.delegate.get_by_id(user_id)
+
+        # Cache the result (even None results could be cached with short TTL)
+        if user is not None:
+            await self.cache.set(key, user.to_dict(), self._ttl)
+            await self.cache.set(self._email_key(user.email), user.to_dict(), self._ttl)
+
+        return user
+
+    async def get_by_email(self, email: str) -> User | None:
+        """Get user by email with caching."""
+        key = self._email_key(email)
+        cached = await self.cache.get(key)
+        if cached is not None:
+            return User.from_dict(cached)
+
+        user = await self.delegate.get_by_email(email)
+
+        if user is not None:
+            await self.cache.set(key, user.to_dict(), self._ttl)
+            await self.cache.set(self._user_key(user.id), user.to_dict(), self._ttl)
+
+        return user
+
+    async def save(self, user: User) -> None:
+        """Save user and invalidate cache.
+
+        Write-through with cache invalidation:
+        1. Save to database
+        2. Invalidate cached entries
+        """
+        await self.delegate.save(user)
+
+        # Invalidate cache (could also update cache here for write-through)
+        await self.cache.delete(self._user_key(user.id))
+        await self.cache.delete(self._email_key(user.email))
+
+    async def delete(self, user_id: str) -> None:
+        """Delete user and invalidate cache."""
+        # Get user first to know email for cache invalidation
+        user = await self.delegate.get_by_id(user_id)
+
+        await self.delegate.delete(user_id)
+
+        # Invalidate cache
+        await self.cache.delete(self._user_key(user_id))
+        if user:
+            await self.cache.delete(self._email_key(user.email))
+
+    async def list_all(self) -> list[User]:
+        """List all users (no caching for list operations).
+
+        Note: Caching list operations is more complex and often not worth it
+        because the list can become stale quickly.
+        """
+        return await self.delegate.list_all()

--- a/examples/patterns/caching/app/adapters/fakes.py
+++ b/examples/patterns/caching/app/adapters/fakes.py
@@ -1,0 +1,123 @@
+"""Fake adapters for testing.
+
+In tests, we use simple fakes without caching complexity.
+This demonstrates profile-based switching.
+"""
+
+import fnmatch
+from typing import Any
+
+from dioxide import Profile, adapter
+
+from ..domain.models import User
+from ..domain.ports import CachePort, UserRepositoryPort
+
+
+@adapter.for_(UserRepositoryPort, profile=Profile.TEST)
+class FakeUserRepository:
+    """Simple in-memory user repository for testing.
+
+    No caching complexity - just direct storage.
+    This shows how tests can use a simpler implementation.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with empty storage."""
+        self.users: dict[str, User] = {}
+        self._email_index: dict[str, str] = {}
+
+    async def get_by_id(self, user_id: str) -> User | None:
+        """Get user from in-memory storage."""
+        return self.users.get(user_id)
+
+    async def get_by_email(self, email: str) -> User | None:
+        """Get user by email from in-memory storage."""
+        user_id = self._email_index.get(email)
+        if user_id:
+            return self.users.get(user_id)
+        return None
+
+    async def save(self, user: User) -> None:
+        """Save user to in-memory storage."""
+        self.users[user.id] = user
+        self._email_index[user.email] = user.id
+
+    async def delete(self, user_id: str) -> None:
+        """Delete user from in-memory storage."""
+        user = self.users.get(user_id)
+        if user:
+            del self.users[user_id]
+            if user.email in self._email_index:
+                del self._email_index[user.email]
+
+    async def list_all(self) -> list[User]:
+        """List all users from in-memory storage."""
+        return list(self.users.values())
+
+    # Test helpers
+    def seed(self, *users: User) -> None:
+        """Seed repository with test data."""
+        for user in users:
+            self.users[user.id] = user
+            self._email_index[user.email] = user.id
+
+    def clear(self) -> None:
+        """Clear all users."""
+        self.users.clear()
+        self._email_index.clear()
+
+
+@adapter.for_(CachePort, profile=Profile.TEST)
+class FakeCache:
+    """Fake cache for testing cache behavior.
+
+    Tracks hits, misses, and operations for test assertions.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with empty cache and counters."""
+        self.data: dict[str, Any] = {}
+        self.hit_count: int = 0
+        self.miss_count: int = 0
+        self.set_count: int = 0
+        self.delete_count: int = 0
+
+    async def get(self, key: str) -> Any | None:
+        """Get value and track hit/miss."""
+        value = self.data.get(key)
+        if value is not None:
+            self.hit_count += 1
+        else:
+            self.miss_count += 1
+        return value
+
+    async def set(self, key: str, value: Any, ttl_seconds: int = 300) -> None:
+        """Set value and track operation."""
+        self.data[key] = value
+        self.set_count += 1
+
+    async def delete(self, key: str) -> None:
+        """Delete value and track operation."""
+        if key in self.data:
+            del self.data[key]
+            self.delete_count += 1
+
+    async def delete_pattern(self, pattern: str) -> None:
+        """Delete matching keys."""
+        keys_to_delete = [k for k in self.data.keys() if fnmatch.fnmatch(k, pattern)]
+        for key in keys_to_delete:
+            del self.data[key]
+            self.delete_count += 1
+
+    # Test helpers
+    def clear(self) -> None:
+        """Clear cache and reset counters."""
+        self.data.clear()
+        self.hit_count = 0
+        self.miss_count = 0
+        self.set_count = 0
+        self.delete_count = 0
+
+    def was_cached(self, key: str) -> bool:
+        """Check if a key is in cache."""
+        return key in self.data

--- a/examples/patterns/caching/app/adapters/postgres.py
+++ b/examples/patterns/caching/app/adapters/postgres.py
@@ -1,0 +1,64 @@
+"""PostgreSQL adapter for direct database access."""
+
+from datetime import datetime
+
+from dioxide import Profile, adapter
+
+from ..domain.models import User
+from ..domain.ports import DatabaseUserRepositoryPort
+
+
+@adapter.for_(DatabaseUserRepositoryPort, profile=Profile.PRODUCTION)
+class PostgresUserRepository:
+    """PostgreSQL user repository (simulated).
+
+    In a real application, this would use asyncpg or SQLAlchemy.
+    This is the "inner" repository that CachingUserRepository wraps.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with sample data."""
+        self._users: dict[str, User] = {
+            "user-1": User(id="user-1", name="Alice", email="alice@example.com", created_at=datetime.now()),
+            "user-2": User(id="user-2", name="Bob", email="bob@example.com", created_at=datetime.now()),
+        }
+        self._email_index: dict[str, str] = {
+            "alice@example.com": "user-1",
+            "bob@example.com": "user-2",
+        }
+        print("  [Postgres] Repository initialized with sample data")
+
+    async def get_by_id(self, user_id: str) -> User | None:
+        """Get user from PostgreSQL (simulated)."""
+        print(f"  [Postgres] Querying user by ID: {user_id}")
+        return self._users.get(user_id)
+
+    async def get_by_email(self, email: str) -> User | None:
+        """Get user by email from PostgreSQL (simulated)."""
+        print(f"  [Postgres] Querying user by email: {email}")
+        user_id = self._email_index.get(email)
+        if user_id:
+            return self._users.get(user_id)
+        return None
+
+    async def save(self, user: User) -> None:
+        """Save user to PostgreSQL (simulated)."""
+        print(f"  [Postgres] Saving user: {user.id}")
+        if user.created_at is None:
+            user.created_at = datetime.now()
+        self._users[user.id] = user
+        self._email_index[user.email] = user.id
+
+    async def delete(self, user_id: str) -> None:
+        """Delete user from PostgreSQL (simulated)."""
+        print(f"  [Postgres] Deleting user: {user_id}")
+        user = self._users.get(user_id)
+        if user:
+            del self._users[user_id]
+            if user.email in self._email_index:
+                del self._email_index[user.email]
+
+    async def list_all(self) -> list[User]:
+        """List all users from PostgreSQL (simulated)."""
+        print(f"  [Postgres] Listing all users (count: {len(self._users)})")
+        return list(self._users.values())

--- a/examples/patterns/caching/app/adapters/redis.py
+++ b/examples/patterns/caching/app/adapters/redis.py
@@ -1,0 +1,48 @@
+"""Redis adapter for caching."""
+
+import fnmatch
+from typing import Any
+
+from dioxide import Profile, adapter
+
+from ..domain.ports import CachePort
+
+
+@adapter.for_(CachePort, profile=Profile.PRODUCTION)
+class RedisCache:
+    """Redis cache adapter (simulated).
+
+    In a real application, this would use aioredis or redis-py.
+    """
+
+    def __init__(self) -> None:
+        """Initialize simulated Redis."""
+        self._cache: dict[str, Any] = {}
+        print("  [Redis] Cache initialized")
+
+    async def get(self, key: str) -> Any | None:
+        """Get value from Redis (simulated)."""
+        value = self._cache.get(key)
+        if value is not None:
+            print(f"  [Redis] Cache HIT: {key}")
+        else:
+            print(f"  [Redis] Cache MISS: {key}")
+        return value
+
+    async def set(self, key: str, value: Any, ttl_seconds: int = 300) -> None:
+        """Set value in Redis with TTL (simulated)."""
+        self._cache[key] = value
+        print(f"  [Redis] Cache SET: {key} (TTL={ttl_seconds}s)")
+
+    async def delete(self, key: str) -> None:
+        """Delete value from Redis (simulated)."""
+        if key in self._cache:
+            del self._cache[key]
+            print(f"  [Redis] Cache DELETE: {key}")
+
+    async def delete_pattern(self, pattern: str) -> None:
+        """Delete all keys matching pattern (simulated SCAN + DEL)."""
+        keys_to_delete = [k for k in self._cache.keys() if fnmatch.fnmatch(k, pattern)]
+        for key in keys_to_delete:
+            del self._cache[key]
+        print(f"  [Redis] Cache DELETE pattern {pattern}: {len(keys_to_delete)} keys")

--- a/examples/patterns/caching/app/domain/__init__.py
+++ b/examples/patterns/caching/app/domain/__init__.py
@@ -1,0 +1,13 @@
+"""Domain layer for caching example."""
+
+from .models import User
+from .ports import CachePort, DatabaseUserRepositoryPort, UserRepositoryPort
+from .services import UserService
+
+__all__ = [
+    "User",
+    "UserRepositoryPort",
+    "DatabaseUserRepositoryPort",
+    "CachePort",
+    "UserService",
+]

--- a/examples/patterns/caching/app/domain/models.py
+++ b/examples/patterns/caching/app/domain/models.py
@@ -1,0 +1,37 @@
+"""Domain models for the caching example."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+
+@dataclass
+class User:
+    """A user in the system."""
+
+    id: str
+    name: str
+    email: str
+    created_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for caching."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "email": self.email,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "User":
+        """Create from dictionary (cache deserialization)."""
+        created_at = None
+        if data.get("created_at"):
+            created_at = datetime.fromisoformat(data["created_at"])
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            email=data["email"],
+            created_at=created_at,
+        )

--- a/examples/patterns/caching/app/domain/ports.py
+++ b/examples/patterns/caching/app/domain/ports.py
@@ -1,0 +1,93 @@
+"""Port definitions for the caching example.
+
+This example has three ports:
+1. UserRepositoryPort - The main interface services use
+2. DatabaseUserRepositoryPort - Direct database access (used by caching wrapper)
+3. CachePort - Cache storage interface
+"""
+
+from typing import Any, Protocol
+
+from .models import User
+
+
+class UserRepositoryPort(Protocol):
+    """Port for user repository operations.
+
+    Services depend on this port. It may be implemented by:
+    - CachingUserRepository (production) - adds caching layer
+    - FakeUserRepository (test) - simple in-memory storage
+    """
+
+    async def get_by_id(self, user_id: str) -> User | None:
+        """Get a user by ID."""
+        ...
+
+    async def get_by_email(self, email: str) -> User | None:
+        """Get a user by email."""
+        ...
+
+    async def save(self, user: User) -> None:
+        """Save a user (create or update)."""
+        ...
+
+    async def delete(self, user_id: str) -> None:
+        """Delete a user by ID."""
+        ...
+
+    async def list_all(self) -> list[User]:
+        """List all users."""
+        ...
+
+
+class DatabaseUserRepositoryPort(Protocol):
+    """Port for direct database access.
+
+    This is the "inner" repository that CachingUserRepository wraps.
+    It provides the actual database operations without caching.
+
+    Why a separate port?
+    - Caching is an infrastructure concern, not domain
+    - We need to inject both the database repo AND cache into the caching wrapper
+    - Test fakes don't need this complexity
+    """
+
+    async def get_by_id(self, user_id: str) -> User | None:
+        """Get a user by ID from database."""
+        ...
+
+    async def get_by_email(self, email: str) -> User | None:
+        """Get a user by email from database."""
+        ...
+
+    async def save(self, user: User) -> None:
+        """Save a user to database."""
+        ...
+
+    async def delete(self, user_id: str) -> None:
+        """Delete a user from database."""
+        ...
+
+    async def list_all(self) -> list[User]:
+        """List all users from database."""
+        ...
+
+
+class CachePort(Protocol):
+    """Port for cache operations."""
+
+    async def get(self, key: str) -> Any | None:
+        """Get a value from cache."""
+        ...
+
+    async def set(self, key: str, value: Any, ttl_seconds: int = 300) -> None:
+        """Set a value in cache with TTL."""
+        ...
+
+    async def delete(self, key: str) -> None:
+        """Delete a value from cache."""
+        ...
+
+    async def delete_pattern(self, pattern: str) -> None:
+        """Delete all keys matching pattern."""
+        ...

--- a/examples/patterns/caching/app/domain/services.py
+++ b/examples/patterns/caching/app/domain/services.py
@@ -1,0 +1,61 @@
+"""Domain services for the caching example."""
+
+from dioxide import service
+
+from .models import User
+from .ports import UserRepositoryPort
+
+
+@service
+class UserService:
+    """User management service.
+
+    This service depends on UserRepositoryPort without knowing
+    whether caching is involved. In production, it gets
+    CachingUserRepository; in tests, it gets FakeUserRepository.
+    """
+
+    def __init__(self, repository: UserRepositoryPort) -> None:
+        """Initialize with repository dependency."""
+        self.repository = repository
+
+    async def get_user(self, user_id: str) -> User | None:
+        """Get a user by ID."""
+        return await self.repository.get_by_id(user_id)
+
+    async def get_user_by_email(self, email: str) -> User | None:
+        """Get a user by email."""
+        return await self.repository.get_by_email(email)
+
+    async def create_user(self, user_id: str, name: str, email: str) -> User:
+        """Create a new user."""
+        user = User(id=user_id, name=name, email=email)
+        await self.repository.save(user)
+        return user
+
+    async def update_user(self, user_id: str, name: str | None = None, email: str | None = None) -> User | None:
+        """Update an existing user."""
+        user = await self.repository.get_by_id(user_id)
+        if user is None:
+            return None
+
+        if name is not None:
+            user.name = name
+        if email is not None:
+            user.email = email
+
+        await self.repository.save(user)
+        return user
+
+    async def delete_user(self, user_id: str) -> bool:
+        """Delete a user."""
+        user = await self.repository.get_by_id(user_id)
+        if user is None:
+            return False
+
+        await self.repository.delete(user_id)
+        return True
+
+    async def list_users(self) -> list[User]:
+        """List all users."""
+        return await self.repository.list_all()

--- a/examples/patterns/caching/app/main.py
+++ b/examples/patterns/caching/app/main.py
@@ -1,0 +1,104 @@
+"""Entry point demonstrating the caching adapter pattern.
+
+This example shows how CachingUserRepository wraps PostgresUserRepository
+with transparent caching using Redis.
+"""
+
+import asyncio
+
+from dioxide import Container, Profile
+
+from .domain import UserService
+
+
+async def main() -> None:
+    """Demonstrate caching adapter pattern."""
+    print("=" * 70)
+    print("Caching Adapter Pattern Example")
+    print("=" * 70)
+    print()
+    print("Architecture:")
+    print("  UserService")
+    print("    -> UserRepositoryPort")
+    print("       -> CachingUserRepository")
+    print("          -> DatabaseUserRepositoryPort (PostgresUserRepository)")
+    print("          -> CachePort (RedisCache)")
+    print()
+
+    container = Container()
+    container.scan("app", profile=Profile.PRODUCTION)
+
+    service = container.resolve(UserService)
+
+    print()
+    print("-" * 70)
+    print("First read: Cache MISS, fetches from database")
+    print("-" * 70)
+    print()
+
+    user = await service.get_user("user-1")
+    if user:
+        print(f"  Result: {user.name} ({user.email})")
+
+    print()
+    print("-" * 70)
+    print("Second read: Cache HIT, no database query")
+    print("-" * 70)
+    print()
+
+    user = await service.get_user("user-1")
+    if user:
+        print(f"  Result: {user.name} ({user.email})")
+
+    print()
+    print("-" * 70)
+    print("Read by email: Cache MISS, then cached")
+    print("-" * 70)
+    print()
+
+    user = await service.get_user_by_email("bob@example.com")
+    if user:
+        print(f"  Result: {user.name} ({user.email})")
+
+    print()
+    print("-" * 70)
+    print("Read by email again: Cache HIT")
+    print("-" * 70)
+    print()
+
+    user = await service.get_user_by_email("bob@example.com")
+    if user:
+        print(f"  Result: {user.name} ({user.email})")
+
+    print()
+    print("-" * 70)
+    print("Update user: Invalidates cache")
+    print("-" * 70)
+    print()
+
+    user = await service.update_user("user-1", name="Alice Updated")
+    if user:
+        print(f"  Updated: {user.name}")
+
+    print()
+    print("-" * 70)
+    print("Read updated user: Cache MISS (was invalidated)")
+    print("-" * 70)
+    print()
+
+    user = await service.get_user("user-1")
+    if user:
+        print(f"  Result: {user.name}")
+
+    print()
+    print("=" * 70)
+    print("Key Takeaways:")
+    print("1. Caching is transparent to UserService")
+    print("2. Cache hits avoid database queries")
+    print("3. Writes invalidate cache entries")
+    print("4. Profile.TEST would use FakeUserRepository (no caching)")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/patterns/caching/pyproject.toml
+++ b/examples/patterns/caching/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "dioxide-caching-example"
+version = "0.1.0"
+description = "Caching adapter pattern example using dioxide"
+requires-python = ">=3.11"
+dependencies = [
+    "dioxide>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+python_classes = ["Describe*", "Test*"]
+python_functions = ["it_*", "test_*"]
+testpaths = ["tests"]

--- a/examples/patterns/caching/requirements-dev.txt
+++ b/examples/patterns/caching/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Development dependencies
+-r requirements.txt
+pytest>=8.0.0
+pytest-asyncio>=0.23.0

--- a/examples/patterns/caching/requirements.txt
+++ b/examples/patterns/caching/requirements.txt
@@ -1,0 +1,2 @@
+# Production dependencies
+dioxide>=1.0.0

--- a/examples/patterns/caching/tests/__init__.py
+++ b/examples/patterns/caching/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the caching example."""

--- a/examples/patterns/caching/tests/conftest.py
+++ b/examples/patterns/caching/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Pytest configuration for caching tests."""
+
+import pytest
+from dioxide import Container, Profile
+
+from app.domain import User, UserRepositoryPort
+from app.domain.ports import CachePort
+
+
+@pytest.fixture
+def container() -> Container:
+    """Create test container."""
+    c = Container()
+    c.scan("app", profile=Profile.TEST)
+    return c
+
+
+@pytest.fixture
+def repository(container: Container) -> UserRepositoryPort:
+    """Get the fake user repository."""
+    return container.resolve(UserRepositoryPort)
+
+
+@pytest.fixture
+def cache(container: Container) -> CachePort:
+    """Get the fake cache."""
+    return container.resolve(CachePort)
+
+
+@pytest.fixture
+def seeded_repository(repository: UserRepositoryPort) -> UserRepositoryPort:
+    """Repository with test data."""
+    repository.seed(
+        User(id="user-1", name="Alice", email="alice@example.com"),
+        User(id="user-2", name="Bob", email="bob@example.com"),
+    )
+    return repository

--- a/examples/patterns/caching/tests/test_caching.py
+++ b/examples/patterns/caching/tests/test_caching.py
@@ -1,0 +1,183 @@
+"""Tests for caching adapter pattern.
+
+These tests use Profile.TEST which provides FakeUserRepository
+(simple, no caching). This demonstrates that:
+1. Tests don't need caching complexity
+2. Profile switching changes implementation
+3. Service works the same regardless of caching
+"""
+
+from dioxide import Container
+
+from app.domain import User, UserService
+from app.domain.ports import CachePort, UserRepositoryPort
+
+
+class DescribeUserService:
+    """Tests for UserService with fake repository."""
+
+    async def it_creates_and_retrieves_user(
+        self,
+        container: Container,
+        seeded_repository: UserRepositoryPort,
+    ) -> None:
+        """UserService CRUD operations work with fakes."""
+        service = container.resolve(UserService)
+
+        user = await service.create_user("user-3", "Charlie", "charlie@example.com")
+
+        assert user.id == "user-3"
+        assert user.name == "Charlie"
+
+        retrieved = await service.get_user("user-3")
+        assert retrieved is not None
+        assert retrieved.name == "Charlie"
+
+    async def it_retrieves_user_by_email(
+        self,
+        container: Container,
+        seeded_repository: UserRepositoryPort,
+    ) -> None:
+        """UserService can lookup by email."""
+        service = container.resolve(UserService)
+
+        user = await service.get_user_by_email("alice@example.com")
+
+        assert user is not None
+        assert user.name == "Alice"
+
+    async def it_updates_user(
+        self,
+        container: Container,
+        seeded_repository: UserRepositoryPort,
+    ) -> None:
+        """UserService can update users."""
+        service = container.resolve(UserService)
+
+        user = await service.update_user("user-1", name="Alice Updated")
+
+        assert user is not None
+        assert user.name == "Alice Updated"
+
+        retrieved = await service.get_user("user-1")
+        assert retrieved.name == "Alice Updated"
+
+    async def it_deletes_user(
+        self,
+        container: Container,
+        seeded_repository: UserRepositoryPort,
+    ) -> None:
+        """UserService can delete users."""
+        service = container.resolve(UserService)
+
+        deleted = await service.delete_user("user-1")
+
+        assert deleted is True
+
+        retrieved = await service.get_user("user-1")
+        assert retrieved is None
+
+    async def it_lists_all_users(
+        self,
+        container: Container,
+        seeded_repository: UserRepositoryPort,
+    ) -> None:
+        """UserService can list all users."""
+        service = container.resolve(UserService)
+
+        users = await service.list_users()
+
+        assert len(users) == 2
+        names = {u.name for u in users}
+        assert names == {"Alice", "Bob"}
+
+
+class DescribeFakeRepository:
+    """Tests demonstrating fake repository behavior."""
+
+    async def it_uses_fake_repository_in_test_profile(
+        self,
+        container: Container,
+    ) -> None:
+        """TEST profile uses FakeUserRepository."""
+        repository = container.resolve(UserRepositoryPort)
+
+        assert hasattr(repository, "users")
+        assert hasattr(repository, "seed")
+
+    async def it_provides_test_helpers(
+        self,
+        container: Container,
+    ) -> None:
+        """FakeUserRepository has convenient test helpers."""
+        repository = container.resolve(UserRepositoryPort)
+
+        repository.seed(
+            User(id="test-1", name="Test User", email="test@example.com"),
+        )
+
+        user = await repository.get_by_id("test-1")
+        assert user is not None
+        assert user.name == "Test User"
+
+        repository.clear()
+        user = await repository.get_by_id("test-1")
+        assert user is None
+
+
+class DescribeFakeCache:
+    """Tests demonstrating fake cache behavior."""
+
+    async def it_tracks_cache_operations(
+        self,
+        container: Container,
+        cache: CachePort,
+    ) -> None:
+        """FakeCache tracks operations for testing."""
+        await cache.set("key1", "value1")
+        await cache.get("key1")
+        await cache.get("key2")
+
+        assert cache.set_count == 1
+        assert cache.hit_count == 1
+        assert cache.miss_count == 1
+
+    async def it_supports_pattern_deletion(
+        self,
+        container: Container,
+        cache: CachePort,
+    ) -> None:
+        """FakeCache supports pattern-based deletion."""
+        await cache.set("user:1", {"id": "1"})
+        await cache.set("user:2", {"id": "2"})
+        await cache.set("product:1", {"id": "1"})
+
+        await cache.delete_pattern("user:*")
+
+        assert not cache.was_cached("user:1")
+        assert not cache.was_cached("user:2")
+        assert cache.was_cached("product:1")
+
+
+class DescribeTestIsolation:
+    """Tests demonstrating test isolation."""
+
+    async def it_starts_with_empty_repository(
+        self,
+        container: Container,
+    ) -> None:
+        """Each test gets a fresh container."""
+        repository = container.resolve(UserRepositoryPort)
+
+        users = await repository.list_all()
+        assert len(users) == 0
+
+    async def it_also_starts_with_empty_cache(
+        self,
+        container: Container,
+        cache: CachePort,
+    ) -> None:
+        """Each test gets a fresh cache."""
+        assert cache.hit_count == 0
+        assert cache.miss_count == 0
+        assert len(cache.data) == 0

--- a/examples/patterns/circular-deps/README.md
+++ b/examples/patterns/circular-deps/README.md
@@ -1,0 +1,230 @@
+# Circular Dependency Detection and Resolution Example
+
+This example demonstrates how dioxide detects circular dependencies at startup
+and how to refactor your code to eliminate them.
+
+## What This Example Demonstrates
+
+1. **Circular dependency detection**: dioxide catches cycles at container initialization
+2. **Clear error messages**: Error tells you exactly which types form the cycle
+3. **Refactoring patterns**: Three strategies to break circular dependencies
+4. **Architecture improvements**: Better design emerges from fixing cycles
+
+## Why Circular Dependencies Are Bad
+
+Circular dependencies indicate a design flaw:
+
+```
+ServiceA -> ServiceB -> ServiceA  (cycle!)
+```
+
+Problems:
+- **Initialization order**: Which service gets created first?
+- **Testing difficulty**: Can't test one without the other
+- **Tight coupling**: Changes ripple through the cycle
+- **Code smell**: Usually indicates responsibilities are mixed
+
+## dioxide's Approach
+
+dioxide does NOT support circular dependencies. Instead of hiding the problem
+with lazy injection or Provider patterns, dioxide fails fast at startup with
+a clear error message showing the cycle.
+
+**This is intentional.** Circular dependencies are a design flaw, not something
+to work around with framework tricks.
+
+## Running the Example
+
+```bash
+# From the dioxide repository root
+cd examples/patterns/circular-deps
+
+# Run the problem demonstration (shows error)
+python problem.py
+
+# Run the solution demonstration
+python solution.py
+```
+
+## The Problem
+
+Here's a common circular dependency pattern:
+
+```python
+# The Problem: OrderService and NotificationService depend on each other
+
+class OrderService:
+    def __init__(self, notifications: NotificationService):
+        self.notifications = notifications
+
+    def create_order(self, data):
+        order = Order(**data)
+        self.notifications.notify_order_created(order)
+        return order
+
+class NotificationService:
+    def __init__(self, orders: OrderService):
+        self.orders = orders
+
+    def notify_order_status_change(self, order_id: str):
+        order = self.orders.get_order(order_id)  # Needs order details!
+        self.send_email(order.customer_email, f"Order {order_id} status changed")
+```
+
+When dioxide tries to resolve `OrderService`:
+1. It needs `NotificationService`
+2. `NotificationService` needs `OrderService`
+3. **Cycle detected!**
+
+## dioxide's Error Message
+
+```
+CircularDependencyError: Circular dependency detected:
+  OrderService -> NotificationService -> OrderService
+
+Refactoring suggestions:
+1. Extract shared logic to a new service
+2. Use an event-based pattern (publisher/subscriber)
+3. Pass data instead of service references
+```
+
+## Solutions
+
+### Solution 1: Extract Shared Data Access
+
+If `NotificationService` only needs order data (not full service):
+
+```python
+# Extract an OrderRepository for data access
+class OrderRepositoryPort(Protocol):
+    async def get_by_id(self, order_id: str) -> Order: ...
+
+@service
+class OrderService:
+    def __init__(
+        self,
+        repository: OrderRepositoryPort,
+        notifications: NotificationService,
+    ):
+        self.repository = repository
+        self.notifications = notifications
+
+@service
+class NotificationService:
+    def __init__(self, repository: OrderRepositoryPort):
+        # Now depends on data, not service
+        self.repository = repository
+
+    async def notify_order_status_change(self, order_id: str):
+        order = await self.repository.get_by_id(order_id)
+        await self.send_email(order.customer_email, ...)
+```
+
+Now: `OrderService -> NotificationService -> OrderRepository` (no cycle!)
+
+### Solution 2: Event-Based Communication
+
+Use domain events to decouple services:
+
+```python
+class EventBusPort(Protocol):
+    async def publish(self, event: DomainEvent) -> None: ...
+    def subscribe(self, event_type: type, handler: Callable) -> None: ...
+
+@service
+class OrderService:
+    def __init__(self, repository: OrderRepositoryPort, events: EventBusPort):
+        self.repository = repository
+        self.events = events
+
+    async def create_order(self, data) -> Order:
+        order = Order(**data)
+        await self.repository.save(order)
+        await self.events.publish(OrderCreated(order_id=order.id))
+        return order
+
+@service
+class NotificationService:
+    def __init__(self, events: EventBusPort, repository: OrderRepositoryPort):
+        self.repository = repository
+        events.subscribe(OrderCreated, self.handle_order_created)
+
+    async def handle_order_created(self, event: OrderCreated):
+        order = await self.repository.get_by_id(event.order_id)
+        await self.send_welcome_email(order)
+```
+
+Now: Both services depend on `EventBusPort` (no direct dependency!)
+
+### Solution 3: Pass Data Instead of References
+
+Sometimes the simplest fix is passing data directly:
+
+```python
+@service
+class OrderService:
+    def __init__(self, repository: OrderRepositoryPort):
+        self.repository = repository
+
+    async def create_order(self, data) -> Order:
+        order = Order(**data)
+        await self.repository.save(order)
+        return order  # Caller handles notification
+
+# In controller/use case layer:
+class CreateOrderUseCase:
+    def __init__(self, orders: OrderService, notifications: NotificationService):
+        self.orders = orders
+        self.notifications = notifications
+
+    async def execute(self, data) -> Order:
+        order = await self.orders.create_order(data)
+        await self.notifications.notify_order_created(order)  # Pass data!
+        return order
+```
+
+Now: Use case orchestrates, services are independent.
+
+## Best Practices
+
+### Detect Cycles Early
+
+dioxide fails at container initialization, not at resolution time. This means:
+- CI catches cycles immediately
+- No runtime surprises in production
+- Clear error messages with cycle path
+
+### Prefer Events for Cross-Cutting Concerns
+
+Notifications, logging, and analytics often create cycles. Events break them:
+
+```python
+# Instead of:
+OrderService -> NotificationService -> OrderService
+
+# Use:
+OrderService -> EventBus <- NotificationService
+              (publish)      (subscribe)
+```
+
+### Keep Services Focused
+
+If ServiceA needs ServiceB and ServiceB needs ServiceA, ask:
+- Are responsibilities mixed?
+- Should this be one service?
+- Is there missing abstraction?
+
+## Files
+
+```
+circular-deps/
+├── README.md           # This file
+├── problem.py          # Demonstrates the circular dependency error
+└── solution.py         # Shows refactored, working solution
+```
+
+## Learn More
+
+- [dioxide Documentation](https://github.com/mikelane/dioxide)
+- [Dependency Inversion Principle](https://en.wikipedia.org/wiki/Dependency_inversion_principle)
+- [Event-Driven Architecture](https://martinfowler.com/articles/201701-event-driven.html)

--- a/examples/patterns/circular-deps/problem.py
+++ b/examples/patterns/circular-deps/problem.py
@@ -1,0 +1,160 @@
+"""Demonstration of circular dependency detection in dioxide.
+
+This file shows what happens when you have a circular dependency.
+dioxide detects the cycle at container initialization and raises a clear error.
+
+Run this file to see the error message:
+    python problem.py
+
+Expected output:
+    CircularDependencyError showing the cycle path
+"""
+
+from typing import Protocol
+
+from dioxide import Container, Profile, adapter, service
+
+
+# =============================================================================
+# The Problem: Two services that depend on each other
+# =============================================================================
+
+
+class OrderServicePort(Protocol):
+    """Port for order operations."""
+
+    async def create_order(self, customer_id: str, items: list) -> dict:
+        ...
+
+    async def get_order(self, order_id: str) -> dict:
+        ...
+
+
+class NotificationServicePort(Protocol):
+    """Port for notification operations."""
+
+    async def notify_order_created(self, order: dict) -> None:
+        ...
+
+    async def notify_order_status_change(self, order_id: str, new_status: str) -> None:
+        ...
+
+
+# The circular dependency:
+# OrderService needs NotificationService to send notifications
+# NotificationService needs OrderService to get order details
+
+
+@adapter.for_(OrderServicePort, profile=Profile.PRODUCTION)
+class OrderService:
+    """Order service that sends notifications on order creation.
+
+    Problem: Depends on NotificationService.
+    """
+
+    def __init__(self, notifications: NotificationServicePort) -> None:
+        self.notifications = notifications
+        self._orders: dict[str, dict] = {}
+        self._next_id = 1
+
+    async def create_order(self, customer_id: str, items: list) -> dict:
+        """Create order and notify customer."""
+        order = {
+            "id": f"order-{self._next_id}",
+            "customer_id": customer_id,
+            "items": items,
+            "status": "created",
+        }
+        self._next_id += 1
+        self._orders[order["id"]] = order
+
+        # This creates the dependency on NotificationService
+        await self.notifications.notify_order_created(order)
+
+        return order
+
+    async def get_order(self, order_id: str) -> dict:
+        """Get order details."""
+        return self._orders.get(order_id, {})
+
+
+@adapter.for_(NotificationServicePort, profile=Profile.PRODUCTION)
+class NotificationService:
+    """Notification service that needs order details.
+
+    Problem: Depends on OrderService to get order details for notifications.
+    """
+
+    def __init__(self, orders: OrderServicePort) -> None:
+        # This creates the circular dependency!
+        self.orders = orders
+
+    async def notify_order_created(self, order: dict) -> None:
+        """Send notification for new order."""
+        print(f"[Email] New order {order['id']} created")
+
+    async def notify_order_status_change(self, order_id: str, new_status: str) -> None:
+        """Send notification for status change.
+
+        This method needs to look up order details (customer email, etc.)
+        which is why NotificationService depends on OrderService.
+        """
+        order = await self.orders.get_order(order_id)
+        print(f"[Email] Order {order_id} status changed to {new_status}")
+        print(f"        Customer: {order.get('customer_id', 'unknown')}")
+
+
+# =============================================================================
+# Demonstration
+# =============================================================================
+
+
+def main() -> None:
+    """Demonstrate circular dependency detection."""
+    print("=" * 70)
+    print("Circular Dependency Detection Example")
+    print("=" * 70)
+    print()
+    print("Attempting to scan container with circular dependency...")
+    print()
+    print("Dependency chain:")
+    print("  OrderService -> NotificationServicePort")
+    print("  NotificationService -> OrderServicePort")
+    print("  OrderServicePort -> OrderService (cycle!)")
+    print()
+
+    container = Container()
+
+    try:
+        # This will fail because of the circular dependency
+        container.scan(profile=Profile.PRODUCTION)
+
+        # If we get here (shouldn't), try to resolve
+        container.resolve(OrderServicePort)
+
+    except Exception as e:
+        print("-" * 70)
+        print("dioxide detected the circular dependency!")
+        print("-" * 70)
+        print()
+        print(f"Error type: {type(e).__name__}")
+        print(f"Error message: {e}")
+        print()
+        print("-" * 70)
+        print("What to do:")
+        print("-" * 70)
+        print()
+        print("1. Extract shared data access to a repository")
+        print("   OrderService -> OrderRepository <- NotificationService")
+        print()
+        print("2. Use event-based communication")
+        print("   OrderService -> EventBus <- NotificationService")
+        print()
+        print("3. Pass data instead of service references")
+        print("   Controller orchestrates both services")
+        print()
+        print("See solution.py for the fixed version!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/patterns/circular-deps/solution.py
+++ b/examples/patterns/circular-deps/solution.py
@@ -1,0 +1,325 @@
+"""Solution: Breaking circular dependencies with event-based communication.
+
+This file shows how to refactor the circular dependency from problem.py
+using an event-based approach.
+
+Before (circular):
+    OrderService <-> NotificationService
+
+After (decoupled):
+    OrderService -> EventBus <- NotificationService
+
+Run this file to see it working:
+    python solution.py
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Callable, Protocol
+
+from dioxide import Container, Profile, adapter, service
+
+
+# =============================================================================
+# Domain Events
+# =============================================================================
+
+
+@dataclass
+class DomainEvent:
+    """Base class for domain events."""
+
+    pass
+
+
+@dataclass
+class OrderCreated(DomainEvent):
+    """Event published when an order is created."""
+
+    order_id: str
+    customer_id: str
+    items: list[dict[str, Any]]
+    total: float
+
+
+@dataclass
+class OrderStatusChanged(DomainEvent):
+    """Event published when order status changes."""
+
+    order_id: str
+    old_status: str
+    new_status: str
+
+
+# =============================================================================
+# Ports (Interfaces)
+# =============================================================================
+
+
+class OrderRepositoryPort(Protocol):
+    """Port for order data access."""
+
+    async def save(self, order: dict[str, Any]) -> None:
+        ...
+
+    async def get_by_id(self, order_id: str) -> dict[str, Any] | None:
+        ...
+
+
+class EventBusPort(Protocol):
+    """Port for event publishing and subscription."""
+
+    async def publish(self, event: DomainEvent) -> None:
+        ...
+
+    def subscribe(self, event_type: type[DomainEvent], handler: Callable) -> None:
+        ...
+
+
+class EmailPort(Protocol):
+    """Port for sending emails."""
+
+    async def send(self, to: str, subject: str, body: str) -> None:
+        ...
+
+
+# =============================================================================
+# Services (No circular dependency!)
+# =============================================================================
+
+
+@service
+class OrderService:
+    """Order service that publishes events instead of calling NotificationService.
+
+    Dependencies:
+    - OrderRepositoryPort: For data persistence
+    - EventBusPort: For publishing domain events
+
+    Note: No dependency on NotificationService!
+    """
+
+    def __init__(
+        self,
+        repository: OrderRepositoryPort,
+        events: EventBusPort,
+    ) -> None:
+        self.repository = repository
+        self.events = events
+        self._next_id = 1
+
+    async def create_order(
+        self,
+        customer_id: str,
+        items: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Create order and publish OrderCreated event."""
+        total = sum(item.get("price", 0) * item.get("quantity", 1) for item in items)
+
+        order = {
+            "id": f"order-{self._next_id}",
+            "customer_id": customer_id,
+            "items": items,
+            "total": total,
+            "status": "created",
+        }
+        self._next_id += 1
+
+        await self.repository.save(order)
+
+        # Publish event instead of calling NotificationService directly
+        await self.events.publish(
+            OrderCreated(
+                order_id=order["id"],
+                customer_id=customer_id,
+                items=items,
+                total=total,
+            )
+        )
+
+        return order
+
+    async def update_status(self, order_id: str, new_status: str) -> dict[str, Any] | None:
+        """Update order status and publish event."""
+        order = await self.repository.get_by_id(order_id)
+        if order is None:
+            return None
+
+        old_status = order["status"]
+        order["status"] = new_status
+        await self.repository.save(order)
+
+        await self.events.publish(
+            OrderStatusChanged(
+                order_id=order_id,
+                old_status=old_status,
+                new_status=new_status,
+            )
+        )
+
+        return order
+
+
+@service
+class NotificationService:
+    """Notification service that subscribes to events.
+
+    Dependencies:
+    - EventBusPort: For receiving domain events
+    - OrderRepositoryPort: For looking up order details
+    - EmailPort: For sending emails
+
+    Note: No dependency on OrderService!
+    """
+
+    def __init__(
+        self,
+        events: EventBusPort,
+        repository: OrderRepositoryPort,
+        email: EmailPort,
+    ) -> None:
+        self.repository = repository
+        self.email = email
+
+        # Subscribe to events
+        events.subscribe(OrderCreated, self._handle_order_created)
+        events.subscribe(OrderStatusChanged, self._handle_status_changed)
+
+    async def _handle_order_created(self, event: OrderCreated) -> None:
+        """Handle OrderCreated event."""
+        await self.email.send(
+            to=f"{event.customer_id}@example.com",
+            subject=f"Order {event.order_id} Confirmed",
+            body=f"Your order of ${event.total:.2f} has been received!",
+        )
+
+    async def _handle_status_changed(self, event: OrderStatusChanged) -> None:
+        """Handle OrderStatusChanged event."""
+        order = await self.repository.get_by_id(event.order_id)
+        if order:
+            await self.email.send(
+                to=f"{order['customer_id']}@example.com",
+                subject=f"Order {event.order_id} Status Update",
+                body=f"Your order status changed from {event.old_status} to {event.new_status}",
+            )
+
+
+# =============================================================================
+# Adapters
+# =============================================================================
+
+
+@adapter.for_(OrderRepositoryPort, profile=Profile.PRODUCTION)
+class InMemoryOrderRepository:
+    """In-memory order repository for demonstration."""
+
+    def __init__(self) -> None:
+        self.orders: dict[str, dict[str, Any]] = {}
+
+    async def save(self, order: dict[str, Any]) -> None:
+        self.orders[order["id"]] = order
+        print(f"  [Repository] Saved order {order['id']}")
+
+    async def get_by_id(self, order_id: str) -> dict[str, Any] | None:
+        return self.orders.get(order_id)
+
+
+@adapter.for_(EventBusPort, profile=Profile.PRODUCTION)
+class SimpleEventBus:
+    """Simple in-memory event bus."""
+
+    def __init__(self) -> None:
+        self._handlers: dict[type, list[Callable]] = {}
+
+    async def publish(self, event: DomainEvent) -> None:
+        print(f"  [EventBus] Publishing {type(event).__name__}")
+        handlers = self._handlers.get(type(event), [])
+        for handler in handlers:
+            await handler(event)
+
+    def subscribe(self, event_type: type[DomainEvent], handler: Callable) -> None:
+        if event_type not in self._handlers:
+            self._handlers[event_type] = []
+        self._handlers[event_type].append(handler)
+        print(f"  [EventBus] Subscribed {handler.__qualname__} to {event_type.__name__}")
+
+
+@adapter.for_(EmailPort, profile=Profile.PRODUCTION)
+class ConsoleEmail:
+    """Email adapter that prints to console."""
+
+    async def send(self, to: str, subject: str, body: str) -> None:
+        print(f"  [Email] To: {to}")
+        print(f"          Subject: {subject}")
+        print(f"          Body: {body}")
+
+
+# =============================================================================
+# Demonstration
+# =============================================================================
+
+
+async def main() -> None:
+    """Demonstrate the working solution."""
+    print("=" * 70)
+    print("Circular Dependency Solution: Event-Based Communication")
+    print("=" * 70)
+    print()
+    print("New architecture:")
+    print("  OrderService -> EventBusPort <- NotificationService")
+    print("                  (publish)        (subscribe)")
+    print()
+    print("-" * 70)
+    print("Setting up container...")
+    print("-" * 70)
+    print()
+
+    container = Container()
+    container.scan(profile=Profile.PRODUCTION)
+
+    print()
+    print("-" * 70)
+    print("Resolving services...")
+    print("-" * 70)
+    print()
+
+    # Both services can be resolved without circular dependency!
+    order_service = container.resolve(OrderService)
+    _notification_service = container.resolve(NotificationService)
+
+    print()
+    print("-" * 70)
+    print("Creating an order...")
+    print("-" * 70)
+    print()
+
+    order = await order_service.create_order(
+        customer_id="alice",
+        items=[
+            {"name": "Widget", "price": 29.99, "quantity": 2},
+            {"name": "Gadget", "price": 49.99, "quantity": 1},
+        ],
+    )
+
+    print()
+    print("-" * 70)
+    print("Updating order status...")
+    print("-" * 70)
+    print()
+
+    await order_service.update_status(order["id"], "shipped")
+
+    print()
+    print("=" * 70)
+    print("Success! No circular dependency.")
+    print()
+    print("Key changes:")
+    print("1. OrderService publishes events instead of calling NotificationService")
+    print("2. NotificationService subscribes to events instead of depending on OrderService")
+    print("3. Both services can access order data through OrderRepositoryPort")
+    print("4. EventBusPort decouples the communication")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/patterns/dependency-chain/README.md
+++ b/examples/patterns/dependency-chain/README.md
@@ -1,0 +1,195 @@
+# Multi-Service Dependency Chain Example
+
+This example demonstrates a realistic multi-service dependency chain typical of
+production applications. It shows how dioxide handles complex dependency graphs
+where services depend on multiple other services and adapters.
+
+## What This Example Demonstrates
+
+1. **Deep dependency chains**: Controller -> UseCase -> Repository + Cache + Events
+2. **Multiple dependencies per service**: Services can depend on many ports
+3. **Layered architecture**: Clear separation between HTTP, Application, and Domain layers
+4. **Automatic dependency resolution**: dioxide resolves the entire graph automatically
+5. **Testing with fakes**: Each adapter has a test fake for isolated testing
+
+## Architecture Overview
+
+```
+HTTP Layer (Controllers)
+    |
+    v
+Application Layer (Use Cases / Services)
+    |
+    +---> Domain Repositories
+    |         |
+    |         +---> Database Adapter (production)
+    |         +---> In-Memory Adapter (test)
+    |
+    +---> Cache Port
+    |         |
+    |         +---> Redis Adapter (production)
+    |         +---> In-Memory Adapter (test)
+    |
+    +---> Event Publisher Port
+              |
+              +---> Kafka Adapter (production)
+              +---> In-Memory Adapter (test)
+```
+
+## The Dependency Graph
+
+```python
+OrderController
+    |
+    +---> OrderService (Use Case)
+              |
+              +---> OrderRepository (Port)
+              |         -> PostgresOrderRepository (production)
+              |         -> FakeOrderRepository (test)
+              |
+              +---> ProductRepository (Port)
+              |         -> PostgresProductRepository (production)
+              |         -> FakeProductRepository (test)
+              |
+              +---> CachePort
+              |         -> RedisCache (production)
+              |         -> FakeCache (test)
+              |
+              +---> EventPublisher (Port)
+                        -> KafkaEventPublisher (production)
+                        -> FakeEventPublisher (test)
+```
+
+## Running the Example
+
+```bash
+# From the dioxide repository root
+cd examples/patterns/dependency-chain
+
+# Install dependencies (if running standalone)
+pip install -r requirements.txt
+
+# Run the example
+python -m app.main
+
+# Run tests
+pytest tests/ -v
+```
+
+## Key Concepts
+
+### 1. Multiple Dependencies
+
+Services can depend on multiple ports without complexity:
+
+```python
+@service
+class OrderService:
+    def __init__(
+        self,
+        orders: OrderRepositoryPort,
+        products: ProductRepositoryPort,
+        cache: CachePort,
+        events: EventPublisherPort,
+    ):
+        # All dependencies injected automatically
+        self.orders = orders
+        self.products = products
+        self.cache = cache
+        self.events = events
+```
+
+### 2. Dependency Chain Resolution
+
+dioxide resolves the entire dependency graph automatically:
+
+```python
+# Container resolves:
+# 1. CachePort -> RedisCache (or FakeCache)
+# 2. EventPublisherPort -> KafkaEventPublisher (or FakeEventPublisher)
+# 3. OrderRepositoryPort -> PostgresOrderRepository (or FakeOrderRepository)
+# 4. ProductRepositoryPort -> PostgresProductRepository (or FakeProductRepository)
+# 5. OrderService with all dependencies injected
+# 6. OrderController with OrderService injected
+
+controller = container.resolve(OrderController)
+```
+
+### 3. Testing the Full Chain
+
+In tests, the entire chain uses fakes:
+
+```python
+async def test_create_order(container):
+    # Get fakes for verification
+    fake_orders = container.resolve(OrderRepositoryPort)
+    fake_events = container.resolve(EventPublisherPort)
+
+    # Seed test data
+    fake_products = container.resolve(ProductRepositoryPort)
+    fake_products.seed(Product(id="p1", name="Widget", price=10.00))
+
+    # Execute through full chain
+    controller = container.resolve(OrderController)
+    result = await controller.create_order(
+        customer_id="c1",
+        items=[{"product_id": "p1", "quantity": 2}]
+    )
+
+    # Verify side effects
+    assert len(fake_orders.orders) == 1
+    assert len(fake_events.published) == 1
+```
+
+## Why This Pattern Matters
+
+### Testability
+
+- Each layer can be tested in isolation
+- Fakes replace real infrastructure with zero configuration
+- Tests run in milliseconds, not seconds
+
+### Flexibility
+
+- Swap any adapter without changing business logic
+- Add caching, logging, or events without modifying services
+- Support multiple environments (prod, test, dev) with profiles
+
+### Maintainability
+
+- Clear dependency relationships
+- Easy to understand what each service needs
+- Changes are localized to specific adapters
+
+## Files Structure
+
+```
+dependency-chain/
+├── README.md
+├── pyproject.toml
+├── requirements.txt
+├── app/
+│   ├── __init__.py
+│   ├── main.py              # Entry point and container setup
+│   ├── domain/
+│   │   ├── __init__.py
+│   │   ├── models.py        # Domain entities
+│   │   ├── ports.py         # Port definitions (Protocols)
+│   │   └── services.py      # Use cases / business logic
+│   └── adapters/
+│       ├── __init__.py
+│       ├── postgres.py      # Production database adapters
+│       ├── redis.py         # Production cache adapter
+│       ├── kafka.py         # Production event publisher
+│       └── fakes.py         # Test fakes
+└── tests/
+    ├── __init__.py
+    ├── conftest.py          # Test fixtures
+    └── test_order_service.py
+```
+
+## Learn More
+
+- [dioxide Documentation](https://github.com/mikelane/dioxide)
+- [Hexagonal Architecture](https://alistair.cockburn.us/hexagonal-architecture/)
+- [Clean Architecture by Robert Martin](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)

--- a/examples/patterns/dependency-chain/app/__init__.py
+++ b/examples/patterns/dependency-chain/app/__init__.py
@@ -1,0 +1,5 @@
+"""Multi-service dependency chain example.
+
+This example demonstrates how dioxide handles complex dependency graphs
+with multiple services depending on multiple adapters.
+"""

--- a/examples/patterns/dependency-chain/app/adapters/__init__.py
+++ b/examples/patterns/dependency-chain/app/adapters/__init__.py
@@ -1,0 +1,21 @@
+"""Adapter layer: infrastructure implementations.
+
+This layer contains concrete implementations of domain ports for
+different environments (production, test, development).
+"""
+
+from .fakes import FakeCache, FakeEventPublisher, FakeOrderRepository, FakeProductRepository
+from .kafka import KafkaEventPublisher
+from .postgres import PostgresOrderRepository, PostgresProductRepository
+from .redis import RedisCache
+
+__all__ = [
+    "PostgresOrderRepository",
+    "PostgresProductRepository",
+    "RedisCache",
+    "KafkaEventPublisher",
+    "FakeOrderRepository",
+    "FakeProductRepository",
+    "FakeCache",
+    "FakeEventPublisher",
+]

--- a/examples/patterns/dependency-chain/app/adapters/fakes.py
+++ b/examples/patterns/dependency-chain/app/adapters/fakes.py
@@ -1,0 +1,146 @@
+"""Fake adapters for testing.
+
+Fakes are real implementations that use in-memory storage instead of
+external infrastructure. They are fast, deterministic, and allow
+tests to verify behavior without mocking.
+"""
+
+from typing import Any
+
+from dioxide import Profile, adapter
+
+from ..domain.models import Order, Product
+from ..domain.ports import CachePort, EventPublisherPort, OrderRepositoryPort, ProductRepositoryPort
+
+
+@adapter.for_(OrderRepositoryPort, profile=Profile.TEST)
+class FakeOrderRepository:
+    """Test order repository using in-memory storage.
+
+    Features:
+    - Fast (no I/O)
+    - Deterministic (same behavior every time)
+    - Inspectable (tests can check internal state)
+    """
+
+    def __init__(self) -> None:
+        """Initialize with empty storage."""
+        self.orders: dict[str, Order] = {}
+
+    async def save(self, order: Order) -> None:
+        """Save an order to in-memory storage."""
+        self.orders[order.id] = order
+
+    async def get_by_id(self, order_id: str) -> Order | None:
+        """Retrieve an order by ID from in-memory storage."""
+        return self.orders.get(order_id)
+
+    async def list_by_customer(self, customer_id: str) -> list[Order]:
+        """List all orders for a customer from in-memory storage."""
+        return [o for o in self.orders.values() if o.customer_id == customer_id]
+
+    def clear(self) -> None:
+        """Clear all orders (test helper)."""
+        self.orders.clear()
+
+
+@adapter.for_(ProductRepositoryPort, profile=Profile.TEST)
+class FakeProductRepository:
+    """Test product repository using in-memory storage.
+
+    Includes seed() method for setting up test data.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with empty storage."""
+        self.products: dict[str, Product] = {}
+
+    async def get_by_id(self, product_id: str) -> Product | None:
+        """Retrieve a product by ID from in-memory storage."""
+        return self.products.get(product_id)
+
+    async def update_stock(self, product_id: str, quantity_delta: int) -> None:
+        """Update product stock in in-memory storage."""
+        product = self.products.get(product_id)
+        if product:
+            product.stock += quantity_delta
+
+    def seed(self, *products: Product) -> None:
+        """Seed with test products.
+
+        Args:
+            *products: Products to add to the repository
+        """
+        for product in products:
+            self.products[product.id] = product
+
+    def clear(self) -> None:
+        """Clear all products (test helper)."""
+        self.products.clear()
+
+
+@adapter.for_(CachePort, profile=Profile.TEST)
+class FakeCache:
+    """Test cache using in-memory dictionary.
+
+    Allows tests to inspect cache state and verify caching behavior.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with empty cache."""
+        self.cache: dict[str, Any] = {}
+        self.get_calls: list[str] = []
+        self.set_calls: list[tuple[str, Any, int]] = []
+
+    async def get(self, key: str) -> Any | None:
+        """Get a value from in-memory cache."""
+        self.get_calls.append(key)
+        return self.cache.get(key)
+
+    async def set(self, key: str, value: Any, ttl_seconds: int = 300) -> None:
+        """Set a value in in-memory cache."""
+        self.cache[key] = value
+        self.set_calls.append((key, value, ttl_seconds))
+
+    async def delete(self, key: str) -> None:
+        """Delete a value from in-memory cache."""
+        if key in self.cache:
+            del self.cache[key]
+
+    def clear(self) -> None:
+        """Clear cache and call history (test helper)."""
+        self.cache.clear()
+        self.get_calls.clear()
+        self.set_calls.clear()
+
+    def was_cached(self, key: str) -> bool:
+        """Check if a key was cached (test helper)."""
+        return any(call[0] == key for call in self.set_calls)
+
+
+@adapter.for_(EventPublisherPort, profile=Profile.TEST)
+class FakeEventPublisher:
+    """Test event publisher that records published events.
+
+    Allows tests to verify which events were published and with what data.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with empty event list."""
+        self.published: list[dict[str, Any]] = []
+
+    async def publish(self, event_type: str, payload: dict[str, Any]) -> None:
+        """Record event instead of publishing."""
+        self.published.append({"type": event_type, "payload": payload})
+
+    def clear(self) -> None:
+        """Clear all published events (test helper)."""
+        self.published.clear()
+
+    def get_events_of_type(self, event_type: str) -> list[dict[str, Any]]:
+        """Get all events of a specific type (test helper)."""
+        return [e for e in self.published if e["type"] == event_type]
+
+    def was_published(self, event_type: str) -> bool:
+        """Check if an event type was published (test helper)."""
+        return any(e["type"] == event_type for e in self.published)

--- a/examples/patterns/dependency-chain/app/adapters/kafka.py
+++ b/examples/patterns/dependency-chain/app/adapters/kafka.py
@@ -1,0 +1,36 @@
+"""Kafka adapter for production event publishing.
+
+In a real application, this would use aiokafka or confluent-kafka.
+This example simulates the behavior for demonstration purposes.
+"""
+
+from typing import Any
+
+from dioxide import Profile, adapter
+
+from ..domain.ports import EventPublisherPort
+
+
+@adapter.for_(EventPublisherPort, profile=Profile.PRODUCTION)
+class KafkaEventPublisher:
+    """Production event publisher using Kafka.
+
+    In a real implementation, this would:
+    - Use aiokafka for async Kafka operations
+    - Handle serialization (JSON, Avro, Protobuf)
+    - Have proper error handling and retries
+    - Support different topics for different event types
+    """
+
+    def __init__(self) -> None:
+        """Initialize simulated Kafka connection."""
+        print("  [Kafka] Event publisher initialized")
+
+    async def publish(self, event_type: str, payload: dict[str, Any]) -> None:
+        """Publish an event to Kafka.
+
+        Args:
+            event_type: Type of event (used as topic name)
+            payload: Event data
+        """
+        print(f"  [Kafka] Published {event_type} event: {payload}")

--- a/examples/patterns/dependency-chain/app/adapters/postgres.py
+++ b/examples/patterns/dependency-chain/app/adapters/postgres.py
@@ -1,0 +1,79 @@
+"""PostgreSQL adapters for production database operations.
+
+In a real application, these would use asyncpg or SQLAlchemy.
+This example simulates the behavior for demonstration purposes.
+"""
+
+from dioxide import Profile, adapter
+
+from ..domain.models import Order, Product
+from ..domain.ports import OrderRepositoryPort, ProductRepositoryPort
+
+
+@adapter.for_(OrderRepositoryPort, profile=Profile.PRODUCTION)
+class PostgresOrderRepository:
+    """Production order repository using PostgreSQL.
+
+    In a real implementation, this would:
+    - Use asyncpg or SQLAlchemy for async database access
+    - Have proper connection pooling
+    - Use transactions for consistency
+    """
+
+    def __init__(self) -> None:
+        """Initialize with simulated database state."""
+        self._orders: dict[str, Order] = {}
+        print("  [Postgres] Order repository initialized")
+
+    async def save(self, order: Order) -> None:
+        """Save an order to PostgreSQL."""
+        self._orders[order.id] = order
+        print(f"  [Postgres] Saved order {order.id}")
+
+    async def get_by_id(self, order_id: str) -> Order | None:
+        """Retrieve an order by ID from PostgreSQL."""
+        order = self._orders.get(order_id)
+        if order:
+            print(f"  [Postgres] Found order {order_id}")
+        else:
+            print(f"  [Postgres] Order {order_id} not found")
+        return order
+
+    async def list_by_customer(self, customer_id: str) -> list[Order]:
+        """List all orders for a customer from PostgreSQL."""
+        orders = [o for o in self._orders.values() if o.customer_id == customer_id]
+        print(f"  [Postgres] Found {len(orders)} orders for customer {customer_id}")
+        return orders
+
+
+@adapter.for_(ProductRepositoryPort, profile=Profile.PRODUCTION)
+class PostgresProductRepository:
+    """Production product repository using PostgreSQL.
+
+    In a real implementation, this would query the products table.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with sample product data."""
+        self._products: dict[str, Product] = {
+            "prod-001": Product(id="prod-001", name="Widget", price=29.99, stock=100),
+            "prod-002": Product(id="prod-002", name="Gadget", price=49.99, stock=50),
+            "prod-003": Product(id="prod-003", name="Gizmo", price=19.99, stock=200),
+        }
+        print("  [Postgres] Product repository initialized with sample data")
+
+    async def get_by_id(self, product_id: str) -> Product | None:
+        """Retrieve a product by ID from PostgreSQL."""
+        product = self._products.get(product_id)
+        if product:
+            print(f"  [Postgres] Found product {product_id}: {product.name}")
+        else:
+            print(f"  [Postgres] Product {product_id} not found")
+        return product
+
+    async def update_stock(self, product_id: str, quantity_delta: int) -> None:
+        """Update product stock in PostgreSQL."""
+        product = self._products.get(product_id)
+        if product:
+            product.stock += quantity_delta
+            print(f"  [Postgres] Updated {product.name} stock by {quantity_delta}, new stock: {product.stock}")

--- a/examples/patterns/dependency-chain/app/adapters/redis.py
+++ b/examples/patterns/dependency-chain/app/adapters/redis.py
@@ -1,0 +1,47 @@
+"""Redis adapter for production caching.
+
+In a real application, this would use aioredis or redis-py async.
+This example simulates the behavior for demonstration purposes.
+"""
+
+from typing import Any
+
+from dioxide import Profile, adapter
+
+from ..domain.ports import CachePort
+
+
+@adapter.for_(CachePort, profile=Profile.PRODUCTION)
+class RedisCache:
+    """Production cache using Redis.
+
+    In a real implementation, this would:
+    - Use aioredis or redis-py with async support
+    - Have connection pooling
+    - Handle TTL properly with Redis SETEX
+    """
+
+    def __init__(self) -> None:
+        """Initialize simulated Redis connection."""
+        self._cache: dict[str, Any] = {}
+        print("  [Redis] Cache initialized")
+
+    async def get(self, key: str) -> Any | None:
+        """Get a value from Redis."""
+        value = self._cache.get(key)
+        if value is not None:
+            print(f"  [Redis] Cache HIT for {key}")
+        else:
+            print(f"  [Redis] Cache MISS for {key}")
+        return value
+
+    async def set(self, key: str, value: Any, ttl_seconds: int = 300) -> None:
+        """Set a value in Redis with TTL."""
+        self._cache[key] = value
+        print(f"  [Redis] Cached {key} with TTL={ttl_seconds}s")
+
+    async def delete(self, key: str) -> None:
+        """Delete a value from Redis."""
+        if key in self._cache:
+            del self._cache[key]
+            print(f"  [Redis] Deleted {key}")

--- a/examples/patterns/dependency-chain/app/domain/__init__.py
+++ b/examples/patterns/dependency-chain/app/domain/__init__.py
@@ -1,0 +1,20 @@
+"""Domain layer: models, ports, and services.
+
+This layer contains pure business logic with no infrastructure dependencies.
+"""
+
+from .models import Order, OrderItem, Product
+from .ports import CachePort, EventPublisherPort, OrderRepositoryPort, ProductRepositoryPort
+from .services import OrderController, OrderService
+
+__all__ = [
+    "Order",
+    "OrderItem",
+    "Product",
+    "OrderRepositoryPort",
+    "ProductRepositoryPort",
+    "CachePort",
+    "EventPublisherPort",
+    "OrderService",
+    "OrderController",
+]

--- a/examples/patterns/dependency-chain/app/domain/models.py
+++ b/examples/patterns/dependency-chain/app/domain/models.py
@@ -1,0 +1,69 @@
+"""Domain models for the order management system.
+
+These are pure data classes with no dependencies on infrastructure.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass
+class Product:
+    """A product that can be ordered."""
+
+    id: str
+    name: str
+    price: float
+    stock: int = 100
+
+
+@dataclass
+class OrderItem:
+    """A line item in an order."""
+
+    product_id: str
+    product_name: str
+    quantity: int
+    unit_price: float
+
+    @property
+    def total(self) -> float:
+        """Calculate item total."""
+        return self.quantity * self.unit_price
+
+
+@dataclass
+class Order:
+    """An order placed by a customer."""
+
+    id: str
+    customer_id: str
+    items: list[OrderItem]
+    status: str = "pending"
+    created_at: datetime = field(default_factory=datetime.now)
+
+    @property
+    def total(self) -> float:
+        """Calculate order total."""
+        return sum(item.total for item in self.items)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "id": self.id,
+            "customer_id": self.customer_id,
+            "items": [
+                {
+                    "product_id": item.product_id,
+                    "product_name": item.product_name,
+                    "quantity": item.quantity,
+                    "unit_price": item.unit_price,
+                    "total": item.total,
+                }
+                for item in self.items
+            ],
+            "total": self.total,
+            "status": self.status,
+            "created_at": self.created_at.isoformat(),
+        }

--- a/examples/patterns/dependency-chain/app/domain/ports.py
+++ b/examples/patterns/dependency-chain/app/domain/ports.py
@@ -1,0 +1,61 @@
+"""Port definitions (interfaces) for the order management system.
+
+Ports define the contracts between the domain layer and infrastructure.
+They are implemented by adapters for different environments.
+"""
+
+from typing import Any, Protocol
+
+from .models import Order, Product
+
+
+class OrderRepositoryPort(Protocol):
+    """Port for order persistence operations."""
+
+    async def save(self, order: Order) -> None:
+        """Save an order to the repository."""
+        ...
+
+    async def get_by_id(self, order_id: str) -> Order | None:
+        """Retrieve an order by ID."""
+        ...
+
+    async def list_by_customer(self, customer_id: str) -> list[Order]:
+        """List all orders for a customer."""
+        ...
+
+
+class ProductRepositoryPort(Protocol):
+    """Port for product catalog operations."""
+
+    async def get_by_id(self, product_id: str) -> Product | None:
+        """Retrieve a product by ID."""
+        ...
+
+    async def update_stock(self, product_id: str, quantity_delta: int) -> None:
+        """Update product stock (negative for decrease)."""
+        ...
+
+
+class CachePort(Protocol):
+    """Port for caching operations."""
+
+    async def get(self, key: str) -> Any | None:
+        """Get a value from cache."""
+        ...
+
+    async def set(self, key: str, value: Any, ttl_seconds: int = 300) -> None:
+        """Set a value in cache with TTL."""
+        ...
+
+    async def delete(self, key: str) -> None:
+        """Delete a value from cache."""
+        ...
+
+
+class EventPublisherPort(Protocol):
+    """Port for publishing domain events."""
+
+    async def publish(self, event_type: str, payload: dict[str, Any]) -> None:
+        """Publish an event to the event bus."""
+        ...

--- a/examples/patterns/dependency-chain/app/domain/services.py
+++ b/examples/patterns/dependency-chain/app/domain/services.py
@@ -1,0 +1,210 @@
+"""Domain services (use cases) for order management.
+
+Services contain pure business logic and depend only on ports (interfaces),
+not concrete implementations. This makes them testable and portable.
+"""
+
+import uuid
+from typing import Any
+
+from dioxide import service
+
+from .models import Order, OrderItem
+from .ports import CachePort, EventPublisherPort, OrderRepositoryPort, ProductRepositoryPort
+
+
+@service
+class OrderService:
+    """Core business logic for order management.
+
+    This service demonstrates a complex dependency chain:
+    - OrderRepositoryPort for order persistence
+    - ProductRepositoryPort for product catalog
+    - CachePort for caching frequent queries
+    - EventPublisherPort for domain events
+
+    All dependencies are injected automatically by dioxide based on type hints.
+    """
+
+    def __init__(
+        self,
+        orders: OrderRepositoryPort,
+        products: ProductRepositoryPort,
+        cache: CachePort,
+        events: EventPublisherPort,
+    ) -> None:
+        """Initialize with port dependencies.
+
+        Args:
+            orders: Repository for order persistence
+            products: Repository for product catalog
+            cache: Cache for frequently accessed data
+            events: Publisher for domain events
+        """
+        self.orders = orders
+        self.products = products
+        self.cache = cache
+        self.events = events
+
+    async def create_order(
+        self,
+        customer_id: str,
+        items: list[dict[str, Any]],
+    ) -> Order:
+        """Create a new order.
+
+        Business logic:
+        1. Validate all products exist and have sufficient stock
+        2. Create the order with calculated prices
+        3. Decrease stock for each product
+        4. Cache the order for quick retrieval
+        5. Publish OrderCreated event
+
+        Args:
+            customer_id: Customer placing the order
+            items: List of items with product_id and quantity
+
+        Returns:
+            Created order
+
+        Raises:
+            ValueError: If product not found or insufficient stock
+        """
+        order_items: list[OrderItem] = []
+
+        for item in items:
+            product = await self.products.get_by_id(item["product_id"])
+            if product is None:
+                raise ValueError(f"Product {item['product_id']} not found")
+
+            if product.stock < item["quantity"]:
+                raise ValueError(f"Insufficient stock for {product.name}")
+
+            order_items.append(
+                OrderItem(
+                    product_id=product.id,
+                    product_name=product.name,
+                    quantity=item["quantity"],
+                    unit_price=product.price,
+                )
+            )
+
+        order = Order(
+            id=str(uuid.uuid4()),
+            customer_id=customer_id,
+            items=order_items,
+        )
+
+        await self.orders.save(order)
+
+        for item in items:
+            await self.products.update_stock(item["product_id"], -item["quantity"])
+
+        await self.cache.set(f"order:{order.id}", order.to_dict())
+
+        await self.events.publish(
+            "OrderCreated",
+            {
+                "order_id": order.id,
+                "customer_id": customer_id,
+                "total": order.total,
+            },
+        )
+
+        return order
+
+    async def get_order(self, order_id: str) -> Order | None:
+        """Get an order by ID with caching.
+
+        First checks cache, then falls back to repository.
+
+        Args:
+            order_id: Order ID to retrieve
+
+        Returns:
+            Order if found, None otherwise
+        """
+        cached = await self.cache.get(f"order:{order_id}")
+        if cached is not None:
+            return cached
+
+        order = await self.orders.get_by_id(order_id)
+        if order is not None:
+            await self.cache.set(f"order:{order_id}", order.to_dict())
+
+        return order
+
+    async def get_customer_orders(self, customer_id: str) -> list[Order]:
+        """Get all orders for a customer.
+
+        Args:
+            customer_id: Customer ID
+
+        Returns:
+            List of orders
+        """
+        return await self.orders.list_by_customer(customer_id)
+
+
+@service
+class OrderController:
+    """HTTP controller layer for order operations.
+
+    This demonstrates another level in the dependency chain:
+    OrderController -> OrderService -> Multiple Adapters
+
+    In a real application, this would be a FastAPI router or similar.
+    """
+
+    def __init__(self, order_service: OrderService) -> None:
+        """Initialize with service dependency.
+
+        Args:
+            order_service: Business logic service
+        """
+        self.order_service = order_service
+
+    async def create_order(
+        self,
+        customer_id: str,
+        items: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Handle create order request.
+
+        Args:
+            customer_id: Customer placing the order
+            items: List of items with product_id and quantity
+
+        Returns:
+            Order data as dictionary
+        """
+        order = await self.order_service.create_order(customer_id, items)
+        return order.to_dict()
+
+    async def get_order(self, order_id: str) -> dict[str, Any] | None:
+        """Handle get order request.
+
+        Args:
+            order_id: Order ID to retrieve
+
+        Returns:
+            Order data as dictionary or None
+        """
+        order = await self.order_service.get_order(order_id)
+        if order is None:
+            return None
+        if isinstance(order, dict):
+            return order
+        return order.to_dict()
+
+    async def get_customer_orders(self, customer_id: str) -> list[dict[str, Any]]:
+        """Handle list customer orders request.
+
+        Args:
+            customer_id: Customer ID
+
+        Returns:
+            List of order dictionaries
+        """
+        orders = await self.order_service.get_customer_orders(customer_id)
+        return [o.to_dict() for o in orders]

--- a/examples/patterns/dependency-chain/app/main.py
+++ b/examples/patterns/dependency-chain/app/main.py
@@ -1,0 +1,91 @@
+"""Entry point demonstrating multi-service dependency chain.
+
+This example shows how dioxide resolves a complex dependency graph:
+
+    OrderController
+        -> OrderService
+            -> OrderRepositoryPort (-> PostgresOrderRepository)
+            -> ProductRepositoryPort (-> PostgresProductRepository)
+            -> CachePort (-> RedisCache)
+            -> EventPublisherPort (-> KafkaEventPublisher)
+
+All dependencies are resolved automatically based on type hints and profile.
+"""
+
+import asyncio
+
+from dioxide import Container, Profile
+
+from .domain import OrderController
+
+
+async def main() -> None:
+    """Run the dependency chain example."""
+    print("=" * 70)
+    print("Multi-Service Dependency Chain Example")
+    print("=" * 70)
+    print()
+
+    print("Creating container and scanning with PRODUCTION profile...")
+    print()
+
+    container = Container()
+    container.scan("app", profile=Profile.PRODUCTION)
+
+    print()
+    print("-" * 70)
+    print("Resolving OrderController (triggers full dependency chain)")
+    print("-" * 70)
+    print()
+
+    controller = container.resolve(OrderController)
+
+    print()
+    print("-" * 70)
+    print("Creating an order")
+    print("-" * 70)
+    print()
+
+    result = await controller.create_order(
+        customer_id="customer-001",
+        items=[
+            {"product_id": "prod-001", "quantity": 2},
+            {"product_id": "prod-002", "quantity": 1},
+        ],
+    )
+
+    print()
+    print("-" * 70)
+    print("Order created successfully!")
+    print("-" * 70)
+    print()
+    print(f"Order ID: {result['id']}")
+    print(f"Customer: {result['customer_id']}")
+    print(f"Total: ${result['total']:.2f}")
+    print(f"Items: {len(result['items'])}")
+    for item in result["items"]:
+        print(f"  - {item['product_name']}: {item['quantity']} x ${item['unit_price']:.2f} = ${item['total']:.2f}")
+
+    print()
+    print("-" * 70)
+    print("Retrieving order (should hit cache)")
+    print("-" * 70)
+    print()
+
+    retrieved = await controller.get_order(result["id"])
+    print(f"Retrieved order: {retrieved['id']}")
+
+    print()
+    print("=" * 70)
+    print("Example complete!")
+    print()
+    print("Key Takeaways:")
+    print("1. Complex dependency graphs resolved automatically")
+    print("2. Each service gets its dependencies injected via constructor")
+    print("3. Profile determines which adapters are used")
+    print("4. Changing profile swaps entire infrastructure layer")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/patterns/dependency-chain/pyproject.toml
+++ b/examples/patterns/dependency-chain/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "dioxide-dependency-chain-example"
+version = "0.1.0"
+description = "Multi-service dependency chain example using dioxide"
+requires-python = ">=3.11"
+dependencies = [
+    "dioxide>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+python_classes = ["Describe*", "Test*"]
+python_functions = ["it_*", "test_*"]
+testpaths = ["tests"]

--- a/examples/patterns/dependency-chain/requirements-dev.txt
+++ b/examples/patterns/dependency-chain/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Development dependencies
+-r requirements.txt
+pytest>=8.0.0
+pytest-asyncio>=0.23.0

--- a/examples/patterns/dependency-chain/requirements.txt
+++ b/examples/patterns/dependency-chain/requirements.txt
@@ -1,0 +1,2 @@
+# Production dependencies
+dioxide>=1.0.0

--- a/examples/patterns/dependency-chain/tests/__init__.py
+++ b/examples/patterns/dependency-chain/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the dependency chain example."""

--- a/examples/patterns/dependency-chain/tests/conftest.py
+++ b/examples/patterns/dependency-chain/tests/conftest.py
@@ -1,0 +1,53 @@
+"""Pytest configuration and fixtures for dependency chain tests."""
+
+import pytest
+from dioxide import Container, Profile
+
+from app.domain.models import Product
+from app.domain.ports import CachePort, EventPublisherPort, OrderRepositoryPort, ProductRepositoryPort
+
+
+@pytest.fixture
+def container() -> Container:
+    """Create a test container with TEST profile.
+
+    This activates all fake adapters automatically.
+    """
+    c = Container()
+    c.scan("app", profile=Profile.TEST)
+    return c
+
+
+@pytest.fixture
+def orders(container: Container) -> OrderRepositoryPort:
+    """Get the fake order repository."""
+    return container.resolve(OrderRepositoryPort)
+
+
+@pytest.fixture
+def products(container: Container) -> ProductRepositoryPort:
+    """Get the fake product repository."""
+    return container.resolve(ProductRepositoryPort)
+
+
+@pytest.fixture
+def cache(container: Container) -> CachePort:
+    """Get the fake cache."""
+    return container.resolve(CachePort)
+
+
+@pytest.fixture
+def events(container: Container) -> EventPublisherPort:
+    """Get the fake event publisher."""
+    return container.resolve(EventPublisherPort)
+
+
+@pytest.fixture
+def seeded_products(products: ProductRepositoryPort) -> ProductRepositoryPort:
+    """Seed the product repository with test data."""
+    products.seed(
+        Product(id="p1", name="Widget", price=10.00, stock=100),
+        Product(id="p2", name="Gadget", price=25.00, stock=50),
+        Product(id="p3", name="Gizmo", price=5.00, stock=200),
+    )
+    return products

--- a/examples/patterns/dependency-chain/tests/test_order_service.py
+++ b/examples/patterns/dependency-chain/tests/test_order_service.py
@@ -1,0 +1,279 @@
+"""Tests for the order service demonstrating dependency chain testing.
+
+These tests show how to test a service with multiple dependencies using fakes.
+No mocking frameworks needed - just real implementations with in-memory storage.
+"""
+
+import pytest
+from dioxide import Container
+
+from app.domain import OrderController, OrderService
+from app.domain.models import Product
+from app.domain.ports import CachePort, EventPublisherPort, OrderRepositoryPort, ProductRepositoryPort
+
+
+class DescribeOrderService:
+    """Tests for OrderService business logic."""
+
+    async def it_creates_an_order_with_multiple_items(
+        self,
+        container: Container,
+        seeded_products: ProductRepositoryPort,
+        orders: OrderRepositoryPort,
+        events: EventPublisherPort,
+    ) -> None:
+        """OrderService creates order and publishes event."""
+        service = container.resolve(OrderService)
+
+        order = await service.create_order(
+            customer_id="c1",
+            items=[
+                {"product_id": "p1", "quantity": 2},
+                {"product_id": "p2", "quantity": 1},
+            ],
+        )
+
+        assert order.customer_id == "c1"
+        assert len(order.items) == 2
+        assert order.total == 45.00
+
+        assert order.id in orders.orders
+        assert events.was_published("OrderCreated")
+
+    async def it_validates_product_exists(
+        self,
+        container: Container,
+        seeded_products: ProductRepositoryPort,
+    ) -> None:
+        """OrderService raises ValueError for invalid product."""
+        service = container.resolve(OrderService)
+
+        with pytest.raises(ValueError, match="not found"):
+            await service.create_order(
+                customer_id="c1",
+                items=[{"product_id": "invalid", "quantity": 1}],
+            )
+
+    async def it_validates_sufficient_stock(
+        self,
+        container: Container,
+        seeded_products: ProductRepositoryPort,
+    ) -> None:
+        """OrderService raises ValueError for insufficient stock."""
+        service = container.resolve(OrderService)
+
+        with pytest.raises(ValueError, match="Insufficient stock"):
+            await service.create_order(
+                customer_id="c1",
+                items=[{"product_id": "p1", "quantity": 1000}],
+            )
+
+    async def it_decreases_stock_after_order(
+        self,
+        container: Container,
+        seeded_products: ProductRepositoryPort,
+    ) -> None:
+        """OrderService decreases product stock after order."""
+        service = container.resolve(OrderService)
+        product_before = await seeded_products.get_by_id("p1")
+        initial_stock = product_before.stock
+
+        await service.create_order(
+            customer_id="c1",
+            items=[{"product_id": "p1", "quantity": 5}],
+        )
+
+        product_after = await seeded_products.get_by_id("p1")
+        assert product_after.stock == initial_stock - 5
+
+    async def it_caches_order_after_creation(
+        self,
+        container: Container,
+        seeded_products: ProductRepositoryPort,
+        cache: CachePort,
+    ) -> None:
+        """OrderService caches order after creation."""
+        service = container.resolve(OrderService)
+
+        order = await service.create_order(
+            customer_id="c1",
+            items=[{"product_id": "p1", "quantity": 1}],
+        )
+
+        assert cache.was_cached(f"order:{order.id}")
+
+    async def it_retrieves_order_from_cache_on_second_call(
+        self,
+        container: Container,
+        seeded_products: ProductRepositoryPort,
+        cache: CachePort,
+    ) -> None:
+        """OrderService uses cache for order retrieval."""
+        service = container.resolve(OrderService)
+
+        order = await service.create_order(
+            customer_id="c1",
+            items=[{"product_id": "p1", "quantity": 1}],
+        )
+
+        cache.get_calls.clear()
+
+        await service.get_order(order.id)
+
+        assert f"order:{order.id}" in cache.get_calls
+
+
+class DescribeOrderController:
+    """Tests for OrderController API layer."""
+
+    async def it_creates_order_through_full_chain(
+        self,
+        container: Container,
+        seeded_products: ProductRepositoryPort,
+        orders: OrderRepositoryPort,
+        events: EventPublisherPort,
+    ) -> None:
+        """OrderController creates order through service and adapters."""
+        controller = container.resolve(OrderController)
+
+        result = await controller.create_order(
+            customer_id="c1",
+            items=[{"product_id": "p1", "quantity": 3}],
+        )
+
+        assert result["customer_id"] == "c1"
+        assert len(result["items"]) == 1
+        assert result["total"] == 30.00
+
+        assert len(orders.orders) == 1
+
+        order_events = events.get_events_of_type("OrderCreated")
+        assert len(order_events) == 1
+        assert order_events[0]["payload"]["customer_id"] == "c1"
+
+    async def it_retrieves_order(
+        self,
+        container: Container,
+        seeded_products: ProductRepositoryPort,
+    ) -> None:
+        """OrderController retrieves order by ID."""
+        controller = container.resolve(OrderController)
+
+        created = await controller.create_order(
+            customer_id="c1",
+            items=[{"product_id": "p1", "quantity": 1}],
+        )
+
+        result = await controller.get_order(created["id"])
+
+        assert result is not None
+        assert result["id"] == created["id"]
+
+    async def it_returns_none_for_nonexistent_order(
+        self,
+        container: Container,
+    ) -> None:
+        """OrderController returns None for unknown order ID."""
+        controller = container.resolve(OrderController)
+
+        result = await controller.get_order("nonexistent")
+
+        assert result is None
+
+    async def it_lists_customer_orders(
+        self,
+        container: Container,
+        seeded_products: ProductRepositoryPort,
+    ) -> None:
+        """OrderController lists all orders for a customer."""
+        controller = container.resolve(OrderController)
+
+        await controller.create_order(
+            customer_id="c1",
+            items=[{"product_id": "p1", "quantity": 1}],
+        )
+        await controller.create_order(
+            customer_id="c1",
+            items=[{"product_id": "p2", "quantity": 1}],
+        )
+        await controller.create_order(
+            customer_id="c2",
+            items=[{"product_id": "p1", "quantity": 1}],
+        )
+
+        c1_orders = await controller.get_customer_orders("c1")
+        c2_orders = await controller.get_customer_orders("c2")
+
+        assert len(c1_orders) == 2
+        assert len(c2_orders) == 1
+
+
+class DescribeDependencyResolution:
+    """Tests demonstrating dependency chain resolution."""
+
+    def it_resolves_service_with_all_dependencies(
+        self,
+        container: Container,
+    ) -> None:
+        """Container resolves OrderService with all port implementations."""
+        service = container.resolve(OrderService)
+
+        assert service.orders is not None
+        assert service.products is not None
+        assert service.cache is not None
+        assert service.events is not None
+
+    def it_resolves_controller_with_service_dependency(
+        self,
+        container: Container,
+    ) -> None:
+        """Container resolves OrderController with OrderService."""
+        controller = container.resolve(OrderController)
+
+        assert controller.order_service is not None
+        assert controller.order_service.orders is not None
+
+    def it_uses_test_fakes_in_test_profile(
+        self,
+        container: Container,
+    ) -> None:
+        """Container uses fake adapters in TEST profile."""
+        orders = container.resolve(OrderRepositoryPort)
+        products = container.resolve(ProductRepositoryPort)
+        cache = container.resolve(CachePort)
+        events = container.resolve(EventPublisherPort)
+
+        assert hasattr(orders, "orders")
+        assert hasattr(products, "seed")
+        assert hasattr(cache, "get_calls")
+        assert hasattr(events, "published")
+
+
+class DescribeTestIsolation:
+    """Tests demonstrating test isolation with fakes."""
+
+    async def it_provides_clean_state_per_test(
+        self,
+        container: Container,
+        seeded_products: ProductRepositoryPort,
+        orders: OrderRepositoryPort,
+    ) -> None:
+        """Each test starts with clean adapter state."""
+        assert len(orders.orders) == 0
+
+        controller = container.resolve(OrderController)
+        await controller.create_order(
+            customer_id="c1",
+            items=[{"product_id": "p1", "quantity": 1}],
+        )
+
+        assert len(orders.orders) == 1
+
+    async def it_also_provides_clean_state(
+        self,
+        container: Container,
+        seeded_products: ProductRepositoryPort,
+        orders: OrderRepositoryPort,
+    ) -> None:
+        """Fresh container fixture ensures isolation between tests."""
+        assert len(orders.orders) == 0

--- a/examples/patterns/external-api/README.md
+++ b/examples/patterns/external-api/README.md
@@ -1,0 +1,237 @@
+# External API Integration Example
+
+This example demonstrates how to integrate with external APIs (like payment
+gateways) using dioxide, with special focus on testing error scenarios.
+
+## What This Example Demonstrates
+
+1. **External API integration**: Wrapping third-party APIs with ports
+2. **Error injection for testing**: Fake adapters that can simulate failures
+3. **Retry and circuit breaker patterns**: Handling transient failures
+4. **Testing failure scenarios**: Verify your code handles errors gracefully
+
+## Architecture Overview
+
+```
+Production:
+    PaymentService
+        -> PaymentGatewayPort
+            -> StripeAdapter (real Stripe API)
+
+Test:
+    PaymentService
+        -> PaymentGatewayPort
+            -> FakePaymentGateway (controllable, error injection)
+```
+
+## Key Concepts
+
+### 1. Wrapping External APIs with Ports
+
+External APIs should be wrapped in ports for testability:
+
+```python
+class PaymentGatewayPort(Protocol):
+    """Port for payment processing."""
+
+    async def charge(
+        self,
+        amount: Decimal,
+        currency: str,
+        card_token: str,
+    ) -> PaymentResult:
+        """Process a payment."""
+        ...
+
+    async def refund(
+        self,
+        payment_id: str,
+        amount: Decimal | None = None,
+    ) -> RefundResult:
+        """Process a refund."""
+        ...
+```
+
+### 2. Error Injection in Fakes
+
+The fake adapter can be configured to fail in specific ways:
+
+```python
+@adapter.for_(PaymentGatewayPort, profile=Profile.TEST)
+class FakePaymentGateway:
+    def __init__(self):
+        self.should_fail = False
+        self.fail_with: Exception | None = None
+        self.fail_after_n_calls: int | None = None
+        self.call_count = 0
+
+    async def charge(self, amount, currency, card_token):
+        self.call_count += 1
+
+        if self.should_fail:
+            raise self.fail_with or PaymentError("Simulated failure")
+
+        if self.fail_after_n_calls and self.call_count > self.fail_after_n_calls:
+            raise PaymentError("Rate limit exceeded")
+
+        # Success case
+        return PaymentResult(id="pay_fake", status="succeeded")
+```
+
+### 3. Testing Error Scenarios
+
+```python
+async def test_handles_card_declined(container, fake_gateway):
+    fake_gateway.should_fail = True
+    fake_gateway.fail_with = CardDeclinedError("Card declined")
+
+    service = container.resolve(PaymentService)
+
+    result = await service.process_order(order)
+
+    assert result.status == "payment_failed"
+    assert "declined" in result.error_message.lower()
+
+async def test_retries_on_transient_failure(container, fake_gateway):
+    fake_gateway.fail_after_n_calls = 1  # Fail first, succeed after
+    fake_gateway.fail_with = TransientError("Network timeout")
+
+    service = container.resolve(PaymentService)
+
+    result = await service.process_order_with_retry(order)
+
+    assert result.status == "succeeded"
+    assert fake_gateway.call_count == 2  # Retried once
+```
+
+## Running the Example
+
+```bash
+# From the dioxide repository root
+cd examples/patterns/external-api
+
+# Run the example
+python -m app.main
+
+# Run tests
+pytest tests/ -v
+```
+
+## Error Types to Test
+
+### 1. Network Errors
+
+```python
+fake_gateway.fail_with = NetworkError("Connection refused")
+```
+
+### 2. Authentication Errors
+
+```python
+fake_gateway.fail_with = AuthenticationError("Invalid API key")
+```
+
+### 3. Validation Errors
+
+```python
+fake_gateway.fail_with = ValidationError("Invalid card number")
+```
+
+### 4. Card Declined
+
+```python
+fake_gateway.fail_with = CardDeclinedError("Insufficient funds")
+```
+
+### 5. Rate Limiting
+
+```python
+fake_gateway.fail_after_n_calls = 5
+fake_gateway.fail_with = RateLimitError("Too many requests")
+```
+
+### 6. Timeout
+
+```python
+fake_gateway.delay_seconds = 30  # Exceed timeout
+```
+
+## Patterns for Resilience
+
+### Retry Pattern
+
+```python
+@service
+class PaymentService:
+    async def charge_with_retry(
+        self,
+        amount: Decimal,
+        card_token: str,
+        max_retries: int = 3,
+    ) -> PaymentResult:
+        for attempt in range(max_retries):
+            try:
+                return await self.gateway.charge(amount, "USD", card_token)
+            except TransientError:
+                if attempt == max_retries - 1:
+                    raise
+                await asyncio.sleep(2 ** attempt)  # Exponential backoff
+```
+
+### Circuit Breaker Pattern
+
+```python
+@service
+class PaymentService:
+    def __init__(self, gateway: PaymentGatewayPort):
+        self.gateway = gateway
+        self._failure_count = 0
+        self._circuit_open = False
+
+    async def charge(self, amount: Decimal, card_token: str) -> PaymentResult:
+        if self._circuit_open:
+            raise CircuitOpenError("Payment service unavailable")
+
+        try:
+            result = await self.gateway.charge(amount, "USD", card_token)
+            self._failure_count = 0
+            return result
+        except TransientError:
+            self._failure_count += 1
+            if self._failure_count >= 5:
+                self._circuit_open = True
+            raise
+```
+
+## Files Structure
+
+```
+external-api/
+├── README.md
+├── pyproject.toml
+├── requirements.txt
+├── app/
+│   ├── __init__.py
+│   ├── main.py
+│   ├── domain/
+│   │   ├── __init__.py
+│   │   ├── models.py          # PaymentResult, Order, etc.
+│   │   ├── ports.py           # PaymentGatewayPort
+│   │   ├── errors.py          # Custom exceptions
+│   │   └── services.py        # PaymentService
+│   └── adapters/
+│       ├── __init__.py
+│       ├── stripe.py          # Production Stripe adapter
+│       └── fakes.py           # FakePaymentGateway with error injection
+└── tests/
+    ├── __init__.py
+    ├── conftest.py
+    └── test_payment_service.py
+```
+
+## Learn More
+
+- [dioxide Documentation](https://github.com/mikelane/dioxide)
+- [Stripe API Documentation](https://stripe.com/docs/api)
+- [Circuit Breaker Pattern](https://martinfowler.com/bliki/CircuitBreaker.html)
+- [Retry Pattern](https://docs.microsoft.com/en-us/azure/architecture/patterns/retry)

--- a/examples/patterns/external-api/app/__init__.py
+++ b/examples/patterns/external-api/app/__init__.py
@@ -1,0 +1,5 @@
+"""External API integration example with error injection.
+
+This example shows how to integrate with external APIs like payment gateways
+and how to test error scenarios using fake adapters with error injection.
+"""

--- a/examples/patterns/external-api/app/adapters/__init__.py
+++ b/examples/patterns/external-api/app/adapters/__init__.py
@@ -1,0 +1,10 @@
+"""Adapters for external API example."""
+
+from .fakes import FakeOrderRepository, FakePaymentGateway
+from .stripe import StripeAdapter
+
+__all__ = [
+    "StripeAdapter",
+    "FakePaymentGateway",
+    "FakeOrderRepository",
+]

--- a/examples/patterns/external-api/app/adapters/fakes.py
+++ b/examples/patterns/external-api/app/adapters/fakes.py
@@ -1,0 +1,159 @@
+"""Fake adapters with error injection for testing.
+
+These fakes allow tests to control the behavior of external services,
+including simulating various failure modes.
+"""
+
+import uuid
+from decimal import Decimal
+
+from dioxide import Profile, adapter
+
+from ..domain.errors import PaymentError
+from ..domain.models import (
+    Order,
+    PaymentResult,
+    PaymentStatus,
+    RefundResult,
+    RefundStatus,
+)
+from ..domain.ports import OrderRepositoryPort, PaymentGatewayPort
+
+
+@adapter.for_(PaymentGatewayPort, profile=Profile.TEST)
+class FakePaymentGateway:
+    """Fake payment gateway with error injection capabilities.
+
+    This fake allows tests to:
+    - Simulate successful payments
+    - Inject specific errors
+    - Fail after N calls (for retry testing)
+    - Record all calls for verification
+    """
+
+    def __init__(self) -> None:
+        """Initialize with default successful behavior."""
+        self.should_fail: bool = False
+        self.fail_with: Exception | None = None
+        self.fail_after_n_calls: int | None = None
+        self.should_refund_fail: bool = False
+        self.refund_fail_with: Exception | None = None
+
+        self.charge_calls: list[dict] = []
+        self.refund_calls: list[dict] = []
+        self.call_count: int = 0
+
+    async def charge(
+        self,
+        amount: Decimal,
+        currency: str,
+        card_token: str,
+        idempotency_key: str | None = None,
+    ) -> PaymentResult:
+        """Process a fake charge.
+
+        Behavior controlled by:
+        - should_fail: Always fail with fail_with exception
+        - fail_after_n_calls: Fail after N successful calls
+        """
+        self.call_count += 1
+        self.charge_calls.append(
+            {
+                "amount": amount,
+                "currency": currency,
+                "card_token": card_token,
+                "idempotency_key": idempotency_key,
+            }
+        )
+
+        if self.should_fail and self.fail_with:
+            raise self.fail_with
+
+        if self.fail_after_n_calls is not None:
+            if self.call_count <= self.fail_after_n_calls:
+                raise self.fail_with or PaymentError("Simulated transient failure")
+
+        return PaymentResult(
+            id=f"fake_pay_{uuid.uuid4().hex[:8]}",
+            status=PaymentStatus.SUCCEEDED,
+            amount=amount,
+            currency=currency,
+        )
+
+    async def refund(
+        self,
+        payment_id: str,
+        amount: Decimal | None = None,
+        reason: str | None = None,
+    ) -> RefundResult:
+        """Process a fake refund."""
+        self.refund_calls.append(
+            {
+                "payment_id": payment_id,
+                "amount": amount,
+                "reason": reason,
+            }
+        )
+
+        if self.should_refund_fail and self.refund_fail_with:
+            raise self.refund_fail_with
+
+        return RefundResult(
+            id=f"fake_ref_{uuid.uuid4().hex[:8]}",
+            payment_id=payment_id,
+            status=RefundStatus.SUCCEEDED,
+            amount=amount or Decimal("0"),
+        )
+
+    def reset(self) -> None:
+        """Reset fake to default state."""
+        self.should_fail = False
+        self.fail_with = None
+        self.fail_after_n_calls = None
+        self.should_refund_fail = False
+        self.refund_fail_with = None
+        self.charge_calls.clear()
+        self.refund_calls.clear()
+        self.call_count = 0
+
+    def configure_to_fail(self, error: Exception) -> None:
+        """Configure to always fail with given error."""
+        self.should_fail = True
+        self.fail_with = error
+
+    def configure_transient_failure(self, fail_count: int, error: Exception) -> None:
+        """Configure to fail N times then succeed."""
+        self.fail_after_n_calls = fail_count
+        self.fail_with = error
+
+    def was_charged(self, amount: Decimal | None = None) -> bool:
+        """Check if a charge was made."""
+        if amount is None:
+            return len(self.charge_calls) > 0
+        return any(c["amount"] == amount for c in self.charge_calls)
+
+
+@adapter.for_(OrderRepositoryPort, profile=Profile.TEST)
+class FakeOrderRepository:
+    """Fake order repository for testing."""
+
+    def __init__(self) -> None:
+        """Initialize with empty storage."""
+        self.orders: dict[str, Order] = {}
+
+    async def get_by_id(self, order_id: str) -> Order | None:
+        """Get order from in-memory storage."""
+        return self.orders.get(order_id)
+
+    async def save(self, order: Order) -> None:
+        """Save order to in-memory storage."""
+        self.orders[order.id] = order
+
+    def seed(self, *orders: Order) -> None:
+        """Seed with test orders."""
+        for order in orders:
+            self.orders[order.id] = order
+
+    def clear(self) -> None:
+        """Clear all orders."""
+        self.orders.clear()

--- a/examples/patterns/external-api/app/adapters/stripe.py
+++ b/examples/patterns/external-api/app/adapters/stripe.py
@@ -1,0 +1,85 @@
+"""Stripe adapter for production payment processing."""
+
+import uuid
+from decimal import Decimal
+
+from dioxide import Profile, adapter
+
+from ..domain.models import PaymentResult, PaymentStatus, RefundResult, RefundStatus
+from ..domain.ports import PaymentGatewayPort
+
+
+@adapter.for_(PaymentGatewayPort, profile=Profile.PRODUCTION)
+class StripeAdapter:
+    """Production payment gateway using Stripe API.
+
+    In a real implementation, this would use the stripe-python SDK.
+    This example simulates the behavior for demonstration.
+    """
+
+    def __init__(self) -> None:
+        """Initialize Stripe adapter."""
+        print("  [Stripe] Adapter initialized")
+
+    async def charge(
+        self,
+        amount: Decimal,
+        currency: str,
+        card_token: str,
+        idempotency_key: str | None = None,
+    ) -> PaymentResult:
+        """Process a charge via Stripe API.
+
+        In a real implementation:
+        ```python
+        charge = await stripe.Charge.create(
+            amount=int(amount * 100),  # Stripe uses cents
+            currency=currency.lower(),
+            source=card_token,
+            idempotency_key=idempotency_key,
+        )
+        ```
+        """
+        print(f"  [Stripe] Processing charge: ${amount} {currency}")
+        print(f"           Card token: {card_token[:10]}...")
+        print(f"           Idempotency key: {idempotency_key}")
+
+        payment_id = f"ch_{uuid.uuid4().hex[:24]}"
+        print(f"  [Stripe] Charge successful: {payment_id}")
+
+        return PaymentResult(
+            id=payment_id,
+            status=PaymentStatus.SUCCEEDED,
+            amount=amount,
+            currency=currency,
+        )
+
+    async def refund(
+        self,
+        payment_id: str,
+        amount: Decimal | None = None,
+        reason: str | None = None,
+    ) -> RefundResult:
+        """Process a refund via Stripe API.
+
+        In a real implementation:
+        ```python
+        refund = await stripe.Refund.create(
+            charge=payment_id,
+            amount=int(amount * 100) if amount else None,
+            reason=reason,
+        )
+        ```
+        """
+        print(f"  [Stripe] Processing refund for: {payment_id}")
+        print(f"           Amount: {'full' if amount is None else f'${amount}'}")
+
+        refund_id = f"re_{uuid.uuid4().hex[:24]}"
+        print(f"  [Stripe] Refund successful: {refund_id}")
+
+        return RefundResult(
+            id=refund_id,
+            payment_id=payment_id,
+            status=RefundStatus.SUCCEEDED,
+            amount=amount or Decimal("0"),
+        )

--- a/examples/patterns/external-api/app/domain/__init__.py
+++ b/examples/patterns/external-api/app/domain/__init__.py
@@ -1,0 +1,32 @@
+"""Domain layer for external API example."""
+
+from .errors import (
+    AuthenticationError,
+    CardDeclinedError,
+    NetworkError,
+    PaymentError,
+    RateLimitError,
+    TransientError,
+    ValidationError,
+)
+from .models import Order, OrderItem, OrderStatus, PaymentResult, RefundResult
+from .ports import OrderRepositoryPort, PaymentGatewayPort
+from .services import PaymentService
+
+__all__ = [
+    "PaymentResult",
+    "RefundResult",
+    "Order",
+    "OrderItem",
+    "OrderStatus",
+    "PaymentGatewayPort",
+    "OrderRepositoryPort",
+    "PaymentService",
+    "PaymentError",
+    "CardDeclinedError",
+    "ValidationError",
+    "NetworkError",
+    "TransientError",
+    "AuthenticationError",
+    "RateLimitError",
+]

--- a/examples/patterns/external-api/app/domain/errors.py
+++ b/examples/patterns/external-api/app/domain/errors.py
@@ -1,0 +1,47 @@
+"""Custom exceptions for payment operations.
+
+These exceptions represent different failure modes that can occur
+when interacting with external payment APIs.
+"""
+
+
+class PaymentError(Exception):
+    """Base class for payment-related errors."""
+
+    pass
+
+
+class CardDeclinedError(PaymentError):
+    """Raised when a card is declined."""
+
+    pass
+
+
+class ValidationError(PaymentError):
+    """Raised for invalid payment data."""
+
+    pass
+
+
+class NetworkError(PaymentError):
+    """Raised for network-level failures."""
+
+    pass
+
+
+class TransientError(PaymentError):
+    """Raised for temporary failures that may succeed on retry."""
+
+    pass
+
+
+class AuthenticationError(PaymentError):
+    """Raised when API authentication fails."""
+
+    pass
+
+
+class RateLimitError(TransientError):
+    """Raised when rate limits are exceeded."""
+
+    pass

--- a/examples/patterns/external-api/app/domain/models.py
+++ b/examples/patterns/external-api/app/domain/models.py
@@ -1,0 +1,96 @@
+"""Domain models for payment operations."""
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import Enum
+
+
+class PaymentStatus(str, Enum):
+    """Status of a payment."""
+
+    PENDING = "pending"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    REFUNDED = "refunded"
+
+
+class RefundStatus(str, Enum):
+    """Status of a refund."""
+
+    PENDING = "pending"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+@dataclass
+class PaymentResult:
+    """Result of a payment operation."""
+
+    id: str
+    status: PaymentStatus
+    amount: Decimal
+    currency: str
+    error_message: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        """Check if payment succeeded."""
+        return self.status == PaymentStatus.SUCCEEDED
+
+
+@dataclass
+class RefundResult:
+    """Result of a refund operation."""
+
+    id: str
+    payment_id: str
+    status: RefundStatus
+    amount: Decimal
+    error_message: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        """Check if refund succeeded."""
+        return self.status == RefundStatus.SUCCEEDED
+
+
+@dataclass
+class OrderItem:
+    """An item in an order."""
+
+    product_id: str
+    name: str
+    quantity: int
+    unit_price: Decimal
+
+    @property
+    def total(self) -> Decimal:
+        """Calculate item total."""
+        return Decimal(self.quantity) * self.unit_price
+
+
+class OrderStatus(str, Enum):
+    """Status of an order."""
+
+    PENDING = "pending"
+    PAID = "paid"
+    PAYMENT_FAILED = "payment_failed"
+    REFUNDED = "refunded"
+
+
+@dataclass
+class Order:
+    """An order that needs payment."""
+
+    id: str
+    customer_id: str
+    items: list[OrderItem]
+    status: OrderStatus = OrderStatus.PENDING
+    payment_id: str | None = None
+    card_token: str = ""
+    error_message: str | None = None
+
+    @property
+    def total(self) -> Decimal:
+        """Calculate order total."""
+        return sum((item.total for item in self.items), Decimal("0"))

--- a/examples/patterns/external-api/app/domain/ports.py
+++ b/examples/patterns/external-api/app/domain/ports.py
@@ -1,0 +1,75 @@
+"""Port definitions for external API example."""
+
+from decimal import Decimal
+from typing import Protocol
+
+from .models import Order, PaymentResult, RefundResult
+
+
+class PaymentGatewayPort(Protocol):
+    """Port for payment gateway operations.
+
+    This port abstracts the payment gateway (e.g., Stripe, PayPal).
+    In production, it connects to the real API.
+    In tests, it uses a fake with error injection capabilities.
+    """
+
+    async def charge(
+        self,
+        amount: Decimal,
+        currency: str,
+        card_token: str,
+        idempotency_key: str | None = None,
+    ) -> PaymentResult:
+        """Process a payment charge.
+
+        Args:
+            amount: Amount to charge
+            currency: ISO currency code (e.g., "USD")
+            card_token: Tokenized card data
+            idempotency_key: Key to prevent duplicate charges
+
+        Returns:
+            PaymentResult with status and payment ID
+
+        Raises:
+            CardDeclinedError: Card was declined
+            ValidationError: Invalid payment data
+            NetworkError: Network failure
+            TransientError: Temporary failure, retry may succeed
+            AuthenticationError: API key invalid
+        """
+        ...
+
+    async def refund(
+        self,
+        payment_id: str,
+        amount: Decimal | None = None,
+        reason: str | None = None,
+    ) -> RefundResult:
+        """Process a refund.
+
+        Args:
+            payment_id: Original payment ID
+            amount: Amount to refund (None = full refund)
+            reason: Reason for refund
+
+        Returns:
+            RefundResult with status
+
+        Raises:
+            PaymentError: If refund fails
+        """
+        ...
+
+
+class OrderRepositoryPort(Protocol):
+    """Port for order persistence."""
+
+    async def get_by_id(self, order_id: str) -> Order | None:
+        """Get an order by ID."""
+        ...
+
+    async def save(self, order: Order) -> None:
+        """Save an order."""
+        ...

--- a/examples/patterns/external-api/app/domain/services.py
+++ b/examples/patterns/external-api/app/domain/services.py
@@ -1,0 +1,141 @@
+"""Payment service with retry and error handling."""
+
+import asyncio
+import uuid
+
+from dioxide import service
+
+from .errors import CardDeclinedError, PaymentError, TransientError, ValidationError
+from .models import Order, OrderStatus, PaymentResult, PaymentStatus
+from .ports import OrderRepositoryPort, PaymentGatewayPort
+
+
+@service
+class PaymentService:
+    """Service for processing order payments.
+
+    Features:
+    - Automatic retry for transient failures
+    - Proper error handling and order status updates
+    - Idempotency key generation for safe retries
+    """
+
+    def __init__(
+        self,
+        gateway: PaymentGatewayPort,
+        orders: OrderRepositoryPort,
+    ) -> None:
+        """Initialize with dependencies."""
+        self.gateway = gateway
+        self.orders = orders
+
+    async def process_order_payment(
+        self,
+        order: Order,
+        max_retries: int = 3,
+    ) -> Order:
+        """Process payment for an order with automatic retry.
+
+        Args:
+            order: Order to process payment for
+            max_retries: Maximum retry attempts for transient failures
+
+        Returns:
+            Updated order with payment status
+        """
+        if not order.card_token:
+            order.status = OrderStatus.PAYMENT_FAILED
+            order.error_message = "No card token provided"
+            await self.orders.save(order)
+            return order
+
+        idempotency_key = f"order-{order.id}-{uuid.uuid4()}"
+
+        for attempt in range(max_retries):
+            try:
+                result = await self.gateway.charge(
+                    amount=order.total,
+                    currency="USD",
+                    card_token=order.card_token,
+                    idempotency_key=idempotency_key,
+                )
+
+                if result.succeeded:
+                    order.status = OrderStatus.PAID
+                    order.payment_id = result.id
+                    order.error_message = None
+                else:
+                    order.status = OrderStatus.PAYMENT_FAILED
+                    order.error_message = result.error_message
+
+                await self.orders.save(order)
+                return order
+
+            except CardDeclinedError as e:
+                order.status = OrderStatus.PAYMENT_FAILED
+                order.error_message = f"Card declined: {e}"
+                await self.orders.save(order)
+                return order
+
+            except ValidationError as e:
+                order.status = OrderStatus.PAYMENT_FAILED
+                order.error_message = f"Validation error: {e}"
+                await self.orders.save(order)
+                return order
+
+            except TransientError:
+                if attempt == max_retries - 1:
+                    order.status = OrderStatus.PAYMENT_FAILED
+                    order.error_message = "Payment service temporarily unavailable"
+                    await self.orders.save(order)
+                    return order
+                await asyncio.sleep(2**attempt)
+
+            except PaymentError as e:
+                order.status = OrderStatus.PAYMENT_FAILED
+                order.error_message = str(e)
+                await self.orders.save(order)
+                return order
+
+        return order
+
+    async def process_refund(
+        self,
+        order: Order,
+        amount: str | None = None,
+    ) -> Order:
+        """Process a refund for an order.
+
+        Args:
+            order: Order to refund
+            amount: Amount to refund (None = full refund)
+
+        Returns:
+            Updated order with refund status
+        """
+        if order.status != OrderStatus.PAID or not order.payment_id:
+            order.error_message = "Cannot refund: order not paid"
+            return order
+
+        try:
+            from decimal import Decimal
+
+            refund_amount = Decimal(amount) if amount else None
+            result = await self.gateway.refund(
+                payment_id=order.payment_id,
+                amount=refund_amount,
+            )
+
+            if result.succeeded:
+                order.status = OrderStatus.REFUNDED
+                order.error_message = None
+            else:
+                order.error_message = f"Refund failed: {result.error_message}"
+
+            await self.orders.save(order)
+            return order
+
+        except PaymentError as e:
+            order.error_message = f"Refund failed: {e}"
+            await self.orders.save(order)
+            return order

--- a/examples/patterns/external-api/app/main.py
+++ b/examples/patterns/external-api/app/main.py
@@ -1,0 +1,89 @@
+"""Entry point demonstrating external API integration.
+
+This example shows how to integrate with external APIs (like Stripe)
+and how the fake adapter enables error injection testing.
+"""
+
+import asyncio
+from decimal import Decimal
+
+from dioxide import Container, Profile
+
+from .domain import Order, OrderItem, OrderStatus, PaymentService
+from .domain.ports import OrderRepositoryPort
+
+
+async def main() -> None:
+    """Demonstrate external API integration."""
+    print("=" * 70)
+    print("External API Integration Example")
+    print("=" * 70)
+    print()
+    print("Architecture:")
+    print("  PaymentService")
+    print("    -> PaymentGatewayPort")
+    print("       -> StripeAdapter (production)")
+    print("       -> FakePaymentGateway (test, with error injection)")
+    print()
+
+    container = Container()
+    container.scan("app", profile=Profile.PRODUCTION)
+
+    print("-" * 70)
+    print("Initializing services...")
+    print("-" * 70)
+    print()
+
+    payment_service = container.resolve(PaymentService)
+    order_repo = container.resolve(OrderRepositoryPort)
+
+    order = Order(
+        id="order-001",
+        customer_id="cust-001",
+        items=[
+            OrderItem(product_id="p1", name="Widget", quantity=2, unit_price=Decimal("29.99")),
+            OrderItem(product_id="p2", name="Gadget", quantity=1, unit_price=Decimal("49.99")),
+        ],
+        card_token="tok_visa_4242",
+    )
+    await order_repo.save(order)
+
+    print()
+    print("-" * 70)
+    print(f"Processing payment for order: {order.id}")
+    print(f"Total: ${order.total}")
+    print("-" * 70)
+    print()
+
+    result = await payment_service.process_order_payment(order)
+
+    print()
+    print("-" * 70)
+    print("Payment result:")
+    print("-" * 70)
+    print(f"  Status: {result.status.value}")
+    print(f"  Payment ID: {result.payment_id}")
+    print()
+
+    if result.status == OrderStatus.PAID:
+        print("-" * 70)
+        print("Processing refund...")
+        print("-" * 70)
+        print()
+
+        refund_result = await payment_service.process_refund(result)
+        print()
+        print(f"  Refund status: {refund_result.status.value}")
+
+    print()
+    print("=" * 70)
+    print("Key Takeaways:")
+    print("1. External APIs wrapped in ports for testability")
+    print("2. FakePaymentGateway allows error injection in tests")
+    print("3. PaymentService handles retries for transient failures")
+    print("4. All error scenarios can be tested without real API calls")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/patterns/external-api/pyproject.toml
+++ b/examples/patterns/external-api/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "dioxide-external-api-example"
+version = "0.1.0"
+description = "External API integration example with error injection using dioxide"
+requires-python = ">=3.11"
+dependencies = [
+    "dioxide>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+python_classes = ["Describe*", "Test*"]
+python_functions = ["it_*", "test_*"]
+testpaths = ["tests"]

--- a/examples/patterns/external-api/requirements-dev.txt
+++ b/examples/patterns/external-api/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Development dependencies
+-r requirements.txt
+pytest>=8.0.0
+pytest-asyncio>=0.23.0

--- a/examples/patterns/external-api/requirements.txt
+++ b/examples/patterns/external-api/requirements.txt
@@ -1,0 +1,2 @@
+# Production dependencies
+dioxide>=1.0.0

--- a/examples/patterns/external-api/tests/__init__.py
+++ b/examples/patterns/external-api/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for external API integration example."""

--- a/examples/patterns/external-api/tests/conftest.py
+++ b/examples/patterns/external-api/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Pytest configuration for external API tests."""
+
+from decimal import Decimal
+
+import pytest
+from dioxide import Container, Profile
+
+from app.domain import Order, OrderItem
+from app.domain.ports import OrderRepositoryPort, PaymentGatewayPort
+
+
+@pytest.fixture
+def container() -> Container:
+    """Create test container."""
+    c = Container()
+    c.scan("app", profile=Profile.TEST)
+    return c
+
+
+@pytest.fixture
+def gateway(container: Container) -> PaymentGatewayPort:
+    """Get the fake payment gateway."""
+    return container.resolve(PaymentGatewayPort)
+
+
+@pytest.fixture
+def orders(container: Container) -> OrderRepositoryPort:
+    """Get the fake order repository."""
+    return container.resolve(OrderRepositoryPort)
+
+
+@pytest.fixture
+def sample_order() -> Order:
+    """Create a sample order for testing."""
+    return Order(
+        id="test-order-001",
+        customer_id="test-customer-001",
+        items=[
+            OrderItem(product_id="p1", name="Widget", quantity=2, unit_price=Decimal("10.00")),
+            OrderItem(product_id="p2", name="Gadget", quantity=1, unit_price=Decimal("25.00")),
+        ],
+        card_token="tok_test_card",
+    )

--- a/examples/patterns/external-api/tests/test_payment_service.py
+++ b/examples/patterns/external-api/tests/test_payment_service.py
@@ -1,0 +1,289 @@
+"""Tests for PaymentService demonstrating error injection.
+
+These tests show how to use FakePaymentGateway to test various
+error scenarios without making real API calls.
+"""
+
+from decimal import Decimal
+
+from dioxide import Container
+
+from app.domain import (
+    CardDeclinedError,
+    NetworkError,
+    Order,
+    OrderItem,
+    OrderStatus,
+    PaymentService,
+    RateLimitError,
+    TransientError,
+    ValidationError,
+)
+from app.domain.ports import OrderRepositoryPort, PaymentGatewayPort
+
+
+class DescribePaymentService:
+    """Tests for successful payment scenarios."""
+
+    async def it_processes_payment_successfully(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+        sample_order: Order,
+    ) -> None:
+        """PaymentService processes payment and updates order status."""
+        await orders.save(sample_order)
+        service = container.resolve(PaymentService)
+
+        result = await service.process_order_payment(sample_order)
+
+        assert result.status == OrderStatus.PAID
+        assert result.payment_id is not None
+        assert result.error_message is None
+
+    async def it_records_payment_id_on_order(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+        gateway: PaymentGatewayPort,
+        sample_order: Order,
+    ) -> None:
+        """PaymentService stores payment ID on order."""
+        await orders.save(sample_order)
+        service = container.resolve(PaymentService)
+
+        result = await service.process_order_payment(sample_order)
+
+        assert result.payment_id is not None
+        assert result.payment_id.startswith("fake_pay_")
+
+    async def it_charges_correct_amount(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+        gateway: PaymentGatewayPort,
+        sample_order: Order,
+    ) -> None:
+        """PaymentService charges the order total."""
+        await orders.save(sample_order)
+        service = container.resolve(PaymentService)
+
+        await service.process_order_payment(sample_order)
+
+        assert gateway.was_charged(sample_order.total)
+
+
+class DescribeErrorInjection:
+    """Tests demonstrating error injection capabilities."""
+
+    async def it_handles_card_declined(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+        gateway: PaymentGatewayPort,
+        sample_order: Order,
+    ) -> None:
+        """PaymentService handles card declined gracefully."""
+        gateway.configure_to_fail(CardDeclinedError("Insufficient funds"))
+        await orders.save(sample_order)
+        service = container.resolve(PaymentService)
+
+        result = await service.process_order_payment(sample_order)
+
+        assert result.status == OrderStatus.PAYMENT_FAILED
+        assert "declined" in result.error_message.lower()
+
+    async def it_handles_validation_error(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+        gateway: PaymentGatewayPort,
+        sample_order: Order,
+    ) -> None:
+        """PaymentService handles validation errors."""
+        gateway.configure_to_fail(ValidationError("Invalid card number"))
+        await orders.save(sample_order)
+        service = container.resolve(PaymentService)
+
+        result = await service.process_order_payment(sample_order)
+
+        assert result.status == OrderStatus.PAYMENT_FAILED
+        assert "validation" in result.error_message.lower()
+
+    async def it_handles_network_error(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+        gateway: PaymentGatewayPort,
+        sample_order: Order,
+    ) -> None:
+        """PaymentService handles network errors."""
+        gateway.configure_to_fail(NetworkError("Connection refused"))
+        await orders.save(sample_order)
+        service = container.resolve(PaymentService)
+
+        result = await service.process_order_payment(sample_order)
+
+        assert result.status == OrderStatus.PAYMENT_FAILED
+
+
+class DescribeRetryBehavior:
+    """Tests for retry logic with transient failures."""
+
+    async def it_retries_transient_failures(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+        gateway: PaymentGatewayPort,
+        sample_order: Order,
+    ) -> None:
+        """PaymentService retries on transient failures."""
+        gateway.configure_transient_failure(
+            fail_count=2,
+            error=TransientError("Connection timeout"),
+        )
+        await orders.save(sample_order)
+        service = container.resolve(PaymentService)
+
+        result = await service.process_order_payment(sample_order, max_retries=3)
+
+        assert result.status == OrderStatus.PAID
+        assert gateway.call_count == 3
+
+    async def it_fails_after_max_retries(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+        gateway: PaymentGatewayPort,
+        sample_order: Order,
+    ) -> None:
+        """PaymentService gives up after max retries."""
+        gateway.configure_transient_failure(
+            fail_count=5,
+            error=TransientError("Connection timeout"),
+        )
+        await orders.save(sample_order)
+        service = container.resolve(PaymentService)
+
+        result = await service.process_order_payment(sample_order, max_retries=3)
+
+        assert result.status == OrderStatus.PAYMENT_FAILED
+        assert "unavailable" in result.error_message.lower()
+        assert gateway.call_count == 3
+
+    async def it_handles_rate_limiting(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+        gateway: PaymentGatewayPort,
+        sample_order: Order,
+    ) -> None:
+        """PaymentService handles rate limit errors with retry."""
+        gateway.configure_transient_failure(
+            fail_count=1,
+            error=RateLimitError("Too many requests"),
+        )
+        await orders.save(sample_order)
+        service = container.resolve(PaymentService)
+
+        result = await service.process_order_payment(sample_order)
+
+        assert result.status == OrderStatus.PAID
+
+
+class DescribeRefunds:
+    """Tests for refund functionality."""
+
+    async def it_processes_refund_for_paid_order(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+        gateway: PaymentGatewayPort,
+        sample_order: Order,
+    ) -> None:
+        """PaymentService can refund a paid order."""
+        await orders.save(sample_order)
+        service = container.resolve(PaymentService)
+
+        paid_order = await service.process_order_payment(sample_order)
+        assert paid_order.status == OrderStatus.PAID
+
+        refunded_order = await service.process_refund(paid_order)
+
+        assert refunded_order.status == OrderStatus.REFUNDED
+        assert len(gateway.refund_calls) == 1
+
+    async def it_rejects_refund_for_unpaid_order(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+        sample_order: Order,
+    ) -> None:
+        """PaymentService rejects refund for unpaid orders."""
+        await orders.save(sample_order)
+        service = container.resolve(PaymentService)
+
+        result = await service.process_refund(sample_order)
+
+        assert result.status == OrderStatus.PENDING
+        assert "not paid" in result.error_message.lower()
+
+
+class DescribeMissingCardToken:
+    """Tests for orders without card token."""
+
+    async def it_fails_order_without_card_token(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+    ) -> None:
+        """PaymentService fails orders without card token."""
+        order = Order(
+            id="no-card-order",
+            customer_id="test-customer",
+            items=[OrderItem(product_id="p1", name="Widget", quantity=1, unit_price=Decimal("10.00"))],
+            card_token="",
+        )
+        await orders.save(order)
+        service = container.resolve(PaymentService)
+
+        result = await service.process_order_payment(order)
+
+        assert result.status == OrderStatus.PAYMENT_FAILED
+        assert "card token" in result.error_message.lower()
+
+
+class DescribeFakeGateway:
+    """Tests demonstrating FakePaymentGateway capabilities."""
+
+    async def it_tracks_all_charge_attempts(
+        self,
+        container: Container,
+        orders: OrderRepositoryPort,
+        gateway: PaymentGatewayPort,
+        sample_order: Order,
+    ) -> None:
+        """FakePaymentGateway records all charge attempts."""
+        await orders.save(sample_order)
+        service = container.resolve(PaymentService)
+
+        await service.process_order_payment(sample_order)
+
+        assert len(gateway.charge_calls) == 1
+        assert gateway.charge_calls[0]["amount"] == sample_order.total
+        assert gateway.charge_calls[0]["card_token"] == sample_order.card_token
+
+    async def it_can_be_reset_between_tests(
+        self,
+        container: Container,
+        gateway: PaymentGatewayPort,
+    ) -> None:
+        """FakePaymentGateway can be reset for test isolation."""
+        gateway.configure_to_fail(CardDeclinedError("Test"))
+        assert gateway.should_fail is True
+
+        gateway.reset()
+
+        assert gateway.should_fail is False
+        assert gateway.fail_with is None
+        assert len(gateway.charge_calls) == 0


### PR DESCRIPTION
## Summary

- Create comprehensive real-world pattern examples
- Add migration guides from popular DI frameworks
- Each example is self-contained with its own tests and documentation

## New Examples

### Pattern Examples (`examples/patterns/`)

| Pattern | Description | Tests |
|---------|-------------|-------|
| `dependency-chain/` | Multi-service dependency graph (OrderController → OrderService → Repositories) | 15 |
| `circular-deps/` | Detection and event-based solution for circular dependencies | - |
| `caching/` | CachingRepository pattern with fake cache for testing | 11 |
| `external-api/` | Payment gateway with comprehensive error injection | 14 |

### Migration Guides (`examples/migrations/`)

| From | Description | Tests |
|------|-------------|-------|
| `from-dependency-injector/` | Before/after showing conversion from providers to decorators | 6 |
| `from-injector/` | Before/after showing conversion from Module classes | 6 |

## Key Patterns Demonstrated

1. **Decorator-based registration** - `@adapter.for_()` and `@service` eliminate verbose config
2. **Profile-based testing** - `Profile.TEST` auto-selects fake adapters
3. **Fakes over mocks** - Real in-memory implementations with inspection (`fake.sent_emails`)
4. **Error injection** - Configurable failure modes (`configure_to_fail()`, `fail_after_n_calls`)
5. **Event-based decoupling** - Breaks circular dependencies while maintaining loose coupling

## Changes

- `examples/patterns/dependency-chain/` - New example
- `examples/patterns/circular-deps/` - New example  
- `examples/patterns/caching/` - New example
- `examples/patterns/external-api/` - New example
- `examples/migrations/from-dependency-injector/` - New migration guide
- `examples/migrations/from-injector/` - New migration guide
- `examples/README.md` - Updated with new structure

## Test plan
- [x] All 441 main suite tests pass
- [x] Pattern example tests pass (40+ tests)
- [x] Migration example tests pass (12 tests)
- [x] Each example is self-contained and runnable

Fixes #319