### PR TITLE
docs: Clarify global vs instance container usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,23 @@ assert fake_email.sent_emails[0]["to"] == "test@example.com"
 - **Profiles** (`Profile.PRODUCTION`, `Profile.TEST`): Environment selection
 - **Container**: Auto-wires dependencies based on type hints
 
+### Container Patterns: Global vs Instance
+
+dioxide offers two ways to use the container:
+
+| Pattern | Syntax | Best For |
+|---------|--------|----------|
+| **Instance** (recommended) | `container = Container()` | Libraries, web apps, testing |
+| **Global** | `from dioxide import container` | Simple scripts, CLI tools |
+
+**Instance containers** (shown in examples above) provide better isolation and are easier to test.
+Each `Container()` instance has its own singleton cache and state.
+
+**Global container** is a convenience for simple use cases where passing containers around is tedious.
+For testing with the global container, use `reset_global_container()` between tests.
+
+See [Container Patterns](https://dioxide.readthedocs.io/en/latest/user_guide/container_patterns/) for detailed guidance.
+
 ### When to Use @service vs @adapter
 
 | Use `@service` when... | Use `@adapter.for_()` when... |

--- a/docs/api/dioxide/testing/index.rst
+++ b/docs/api/dioxide/testing/index.rst
@@ -10,38 +10,49 @@ dioxide.testing
    This module provides helpers for writing tests with dioxide, making it easy
    to create isolated test containers with fresh state.
 
-   .. admonition:: Example
+   Instance containers (created via ``Container()`` or ``fresh_container()``) are the
+   **recommended pattern for testing**. Each container instance has its own singleton
+   cache, ensuring complete test isolation without state leakage.
 
-      Using the fresh_container context manager::
+   For guidance on when to use instance containers vs the global container, see
+   the Container Patterns guide: :doc:`/docs/user_guide/container_patterns`
 
-          from dioxide.testing import fresh_container
-          from dioxide import Profile
+   Pytest Plugin Usage:
+       Add the following to your ``conftest.py`` to enable dioxide pytest fixtures::
 
+           pytest_plugins = ['dioxide.testing']
 
-          async def test_user_registration():
-              async with fresh_container(profile=Profile.TEST) as container:
-                  service = container.resolve(UserService)
-                  await service.register('alice@example.com', 'Alice')
+       This makes the following fixtures available:
 
-                  email = container.resolve(EmailPort)
-                  assert len(email.sent_emails) == 1
+       - ``dioxide_container``: Fresh container per test (function-scoped)
+       - ``fresh_container_fixture``: Alias for dioxide_container
+       - ``dioxide_container_session``: Shared container across tests (session-scoped)
 
-      Using with pytest fixtures::
+   Example using fixtures (recommended)::
 
-          import pytest
-          from dioxide.testing import fresh_container
-          from dioxide import Profile
-
-
-          @pytest.fixture
-          async def container():
-              async with fresh_container(profile=Profile.TEST) as c:
-                  yield c
+       # conftest.py
+       pytest_plugins = ['dioxide.testing']
 
 
-          async def test_something(container):
-              service = container.resolve(MyService)
-              # ... test with fresh, isolated container
+       # test_my_service.py
+       async def test_something(dioxide_container):
+           dioxide_container.scan(profile=Profile.TEST)
+           service = dioxide_container.resolve(MyService)
+           # ... test with fresh, isolated container
+
+   Example using fresh_container context manager::
+
+       from dioxide.testing import fresh_container
+       from dioxide import Profile
+
+
+       async def test_user_registration():
+           async with fresh_container(profile=Profile.TEST) as container:
+               service = container.resolve(UserService)
+               await service.register('alice@example.com', 'Alice')
+
+               email = container.resolve(EmailPort)
+               assert len(email.sent_emails) == 1
 
 
 
@@ -51,6 +62,9 @@ Functions
 .. autoapisummary::
 
    dioxide.testing.fresh_container
+   dioxide.testing.dioxide_container
+   dioxide.testing.fresh_container_fixture
+   dioxide.testing.dioxide_container_session
 
 
 Module Contents
@@ -76,3 +90,69 @@ Module Contents
           service = container.resolve(UserService)
           # ... test with isolated container
       # Container automatically cleaned up
+
+
+.. py:function:: dioxide_container()
+
+   Provide a fresh, isolated Container for each test.
+
+   This fixture creates a new Container instance for each test function,
+   ensuring complete isolation between tests. The container is NOT
+   pre-scanned - you should call ``container.scan(profile=...)`` in your
+   test to register components with the desired profile.
+
+   :Yields: A fresh Container instance.
+
+   Example::
+
+       async def test_user_service(dioxide_container):
+           dioxide_container.scan(profile=Profile.TEST)
+           service = dioxide_container.resolve(UserService)
+           result = await service.register_user('Alice', 'alice@example.com')
+           assert result['name'] == 'Alice'
+
+
+.. py:function:: fresh_container_fixture()
+
+   Alternative fixture with name matching the context manager.
+
+   This fixture behaves like ``dioxide_container``, providing a fresh
+   Container for each test. The name matches the ``fresh_container``
+   context manager for consistency.
+
+   :Yields: A fresh Container instance.
+
+   Example::
+
+       async def test_isolated(fresh_container_fixture):
+           fresh_container_fixture.scan(profile=Profile.TEST)
+           # Guaranteed fresh container, no state leakage
+           pass
+
+
+.. py:function:: dioxide_container_session()
+
+   Provide a shared Container for the entire test session.
+
+   This session-scoped fixture creates a single Container instance that is
+   shared across all tests in the session. Use this for performance when
+   tests can safely share container state.
+
+   WARNING: Session-scoped containers share state between tests. Only use
+   this when you understand the implications and tests are designed to
+   handle shared state.
+
+   :Yields: A shared Container instance for the session.
+
+   Example::
+
+       # In conftest.py - scan once at session start
+       @pytest.fixture(scope='session', autouse=True)
+       def setup_session_container(dioxide_container_session):
+           dioxide_container_session.scan(profile=Profile.TEST)
+
+
+       # In tests - just use the pre-scanned container
+       async def test_shared_container(dioxide_container_session):
+           service = dioxide_container_session.resolve(SharedService)
+           # ... use shared container

--- a/docs/index.md
+++ b/docs/index.md
@@ -298,6 +298,7 @@ philosophy
 :caption: User Guide
 
 user_guide/getting_started
+user_guide/container_patterns
 user_guide/services-vs-adapters
 user_guide/hexagonal_architecture
 user_guide/architecture

--- a/docs/user_guide/container_patterns.md
+++ b/docs/user_guide/container_patterns.md
@@ -1,0 +1,365 @@
+# Container Patterns: Global vs Instance
+
+This guide clarifies when to use the **global container** (`from dioxide import container`) versus
+**instance containers** (`Container()`), and the testing implications of each pattern.
+
+## TL;DR: Which Should I Use?
+
+| Pattern | Best For | Testing Approach |
+|---------|----------|------------------|
+| **Instance Container** | Most applications, testing, libraries | `fresh_container()` or new `Container()` per test |
+| **Global Container** | Simple scripts, CLI tools, single-file apps | `reset_global_container()` between tests |
+
+**Default recommendation**: Use **instance containers**. They provide better isolation,
+are easier to test, and prevent state leakage between components.
+
+---
+
+## The Two Patterns
+
+### Pattern 1: Instance Container (Recommended)
+
+Create a new `Container()` instance when you need it. Each instance has its own
+singleton cache and registration state.
+
+```python
+from dioxide import Container, Profile
+
+# Create a fresh container
+container = Container()
+container.scan(profile=Profile.PRODUCTION)
+
+# Resolve services
+user_service = container.resolve(UserService)
+```
+
+**Characteristics:**
+- Each `Container()` is independent
+- Singletons are scoped to the container instance
+- No global state to manage
+- Easy to create isolated test containers
+
+### Pattern 2: Global Container
+
+Import the pre-created global container singleton. Useful for simple applications
+where explicit container passing is overhead.
+
+```python
+from dioxide import container, Profile
+
+# Use the global singleton
+container.scan(profile=Profile.PRODUCTION)
+
+# Resolve services
+user_service = container.resolve(UserService)
+```
+
+**Characteristics:**
+- Single shared instance across your application
+- Singletons persist for the process lifetime
+- Requires explicit reset for test isolation
+- Convenient for simple scripts and CLI tools
+
+---
+
+## When to Use Each Pattern
+
+### Use Instance Container When...
+
+1. **Building a library or package**
+   - Libraries should not pollute global state
+   - Users should control container lifecycle
+
+2. **Writing tests** (strongly recommended)
+   - Each test gets a fresh container with `fresh_container()`
+   - No state leakage between tests
+   - Parallel tests work correctly
+
+3. **Running multiple profiles simultaneously**
+   - Need both production and test containers active
+   - Integration testing with mixed configurations
+
+4. **Building a web application with request scoping**
+   - Each request gets its own scoped container
+   - Clean request isolation
+
+5. **When you want explicit dependency tracking**
+   - Clear ownership of the container
+   - Easier to reason about lifecycle
+
+```python
+# Example: Web application with request scoping
+from dioxide import Container, Profile
+
+def create_app():
+    # Application-level container
+    app_container = Container()
+    app_container.scan(profile=Profile.PRODUCTION)
+    return app_container
+
+# Each request can create a scoped child
+async def handle_request(app_container):
+    async with app_container.create_scope() as request_container:
+        service = request_container.resolve(RequestHandler)
+        return await service.handle()
+```
+
+### Use Global Container When...
+
+1. **Building a simple script**
+   - Single-file applications
+   - Quick prototypes
+
+2. **CLI applications**
+   - Command-line tools with Click integration
+   - One-shot execution with no tests
+
+3. **When passing container explicitly is tedious**
+   - Small applications where DI is simple
+   - Rapid prototyping
+
+4. **Module-level initialization patterns**
+   - Legacy code integration
+   - Gradual adoption of DI
+
+```python
+# Example: Simple CLI script
+from dioxide import container, Profile, adapter, service
+from typing import Protocol
+
+class GreeterPort(Protocol):
+    def greet(self, name: str) -> str: ...
+
+@adapter.for_(GreeterPort, profile=Profile.PRODUCTION)
+class FormalGreeter:
+    def greet(self, name: str) -> str:
+        return f"Good day, {name}."
+
+@service
+class CLI:
+    def __init__(self, greeter: GreeterPort):
+        self.greeter = greeter
+
+    def run(self, name: str):
+        print(self.greeter.greet(name))
+
+# Simple one-liner usage
+container.scan(profile=Profile.PRODUCTION)
+container.resolve(CLI).run("Alice")
+```
+
+---
+
+## Testing Patterns
+
+Testing is where the choice between global and instance containers matters most.
+
+### Testing with Instance Containers (Recommended)
+
+Use `fresh_container()` from `dioxide.testing` for completely isolated tests:
+
+```python
+import pytest
+from dioxide import Profile
+from dioxide.testing import fresh_container
+
+@pytest.fixture
+async def container():
+    """Fresh container per test - complete isolation."""
+    async with fresh_container(profile=Profile.TEST) as c:
+        yield c
+    # Automatic cleanup
+
+async def test_user_registration(container):
+    service = container.resolve(UserService)
+    email = container.resolve(EmailPort)  # Gets FakeEmailAdapter
+
+    await service.register_user("alice@example.com", "Alice")
+
+    # Verify using fake's captured state
+    assert len(email.sent_emails) == 1
+    assert email.sent_emails[0]["to"] == "alice@example.com"
+
+async def test_another_feature(container):
+    # Fresh container - email.sent_emails is empty!
+    email = container.resolve(EmailPort)
+    assert len(email.sent_emails) == 0  # No state from previous test
+```
+
+**Or use the built-in pytest fixtures:**
+
+```python
+# conftest.py
+pytest_plugins = ['dioxide.testing']
+
+# test_my_service.py
+async def test_with_fixture(dioxide_container):
+    dioxide_container.scan(profile=Profile.TEST)
+    service = dioxide_container.resolve(MyService)
+    # ... test with fresh container
+```
+
+**Available fixtures:**
+- `dioxide_container` - Fresh container per test (function-scoped)
+- `fresh_container_fixture` - Alias for `dioxide_container`
+- `dioxide_container_session` - Shared container across tests (session-scoped)
+
+### Testing with Global Container (If You Must)
+
+If you're using the global container pattern, you MUST reset it between tests:
+
+```python
+import pytest
+from dioxide import container, reset_global_container, Profile
+
+@pytest.fixture(autouse=True)
+def isolated_container():
+    """Reset global container before and after each test."""
+    reset_global_container()  # Start fresh
+    container.scan(profile=Profile.TEST)
+    yield
+    reset_global_container()  # Clean up
+
+def test_user_registration():
+    service = container.resolve(UserService)
+    # ... test code ...
+
+def test_another_feature():
+    # Global container was reset - state is clean
+    service = container.resolve(UserService)
+    # ... test code ...
+```
+
+**Warning**: The global container pattern has significant testing pitfalls:
+
+1. **State leakage**: Forgetting to reset causes flaky tests
+2. **Parallel test issues**: Multiple tests accessing global state can race
+3. **Hard to debug**: Failures depend on test execution order
+4. **Fixture order matters**: `autouse=True` must run before other fixtures
+
+---
+
+## Mixing Patterns
+
+In larger applications, you might use both patterns:
+
+```python
+from dioxide import container, Container, Profile
+
+# Global container for production app startup
+container.scan(profile=Profile.PRODUCTION)
+
+# Instance container for isolated test scenarios
+def create_test_container():
+    test_container = Container()
+    test_container.scan(profile=Profile.TEST)
+    return test_container
+```
+
+**This is valid but be careful:**
+- Don't resolve from both containers expecting shared singletons
+- Each container has its own singleton cache
+- Clear documentation helps team members understand which to use where
+
+---
+
+## Migration Guide
+
+### From Global to Instance Pattern
+
+If you're currently using the global container and want to switch to instance containers:
+
+**Before (global):**
+```python
+# app.py
+from dioxide import container, Profile
+
+container.scan(profile=Profile.PRODUCTION)
+
+# other_module.py
+from dioxide import container
+
+def do_something():
+    service = container.resolve(SomeService)
+    # ...
+```
+
+**After (instance):**
+```python
+# app.py
+from dioxide import Container, Profile
+
+def create_container(profile: Profile = Profile.PRODUCTION) -> Container:
+    c = Container()
+    c.scan(profile=profile)
+    return c
+
+# Create once at startup
+app_container = create_container()
+
+# other_module.py
+def do_something(container: Container):
+    service = container.resolve(SomeService)
+    # ...
+
+# Or use dependency injection to get the container
+```
+
+### From Instance to Global Pattern
+
+If you have simple needs and instance passing is tedious:
+
+**Before (instance):**
+```python
+# Every function needs the container
+def handle_request(container):
+    service = container.resolve(SomeService)
+    # ...
+
+def another_function(container):
+    other = container.resolve(OtherService)
+    # ...
+```
+
+**After (global):**
+```python
+from dioxide import container, Profile
+
+# Scan once at startup
+container.scan(profile=Profile.PRODUCTION)
+
+# Use anywhere
+def handle_request():
+    service = container.resolve(SomeService)
+    # ...
+
+def another_function():
+    other = container.resolve(OtherService)
+    # ...
+```
+
+---
+
+## Summary
+
+| Aspect | Instance Container | Global Container |
+|--------|-------------------|------------------|
+| **Creation** | `Container()` | `from dioxide import container` |
+| **Isolation** | Complete per instance | Shared process-wide |
+| **Testing** | `fresh_container()` | `reset_global_container()` |
+| **Singletons** | Per container instance | Per process |
+| **Recommended for** | Libraries, web apps, tests | Scripts, CLIs, prototypes |
+| **Pitfalls** | Must pass container explicitly | State leakage, test flakiness |
+
+**When in doubt, use instance containers.** They're safer, more explicit, and easier
+to test. The global container is a convenience for simple cases where the overhead
+of passing containers around isn't worth it.
+
+---
+
+## See Also
+
+- {doc}`/docs/TESTING_GUIDE` - Comprehensive testing patterns
+- {func}`dioxide.testing.fresh_container` - Context manager for test isolation
+- {func}`dioxide.reset_global_container` - Reset global container state
+- {doc}`getting_started` - Introduction to dioxide

--- a/python/dioxide/__init__.py
+++ b/python/dioxide/__init__.py
@@ -6,8 +6,8 @@ dioxide is a modern dependency injection framework that combines:
 - Type-safe dependency resolution with IDE autocomplete support
 - Profile-based configuration for different environments
 
-Quick Start (using global singleton container):
-    >>> from dioxide import container, service, adapter, Profile
+Quick Start (using instance container - recommended):
+    >>> from dioxide import Container, service, adapter, Profile
     >>> from typing import Protocol
     >>>
     >>> class EmailPort(Protocol):
@@ -23,17 +23,29 @@ Quick Start (using global singleton container):
     ...     def __init__(self, email: EmailPort):
     ...         self.email = email
     >>>
+    >>> container = Container()
     >>> container.scan(profile=Profile.PRODUCTION)
-    >>> service = container.resolve(UserService)
+    >>> user_service = container.resolve(UserService)
     >>> # Or use bracket syntax:
-    >>> service = container[UserService]
+    >>> user_service = container[UserService]
 
-Advanced: Creating separate containers for testing isolation:
-    >>> from dioxide import Container
+Global container (convenient for simple scripts):
+    >>> from dioxide import container, Profile
     >>>
-    >>> test_container = Container()
-    >>> test_container.scan(profile=Profile.TEST)
-    >>> service = test_container.resolve(UserService)
+    >>> container.scan(profile=Profile.PRODUCTION)
+    >>> user_service = container.resolve(UserService)
+    >>>
+    >>> # For testing with global container, use reset_global_container()
+    >>> from dioxide import reset_global_container
+    >>> reset_global_container()
+
+Testing (fresh container per test - recommended):
+    >>> from dioxide.testing import fresh_container
+    >>> from dioxide import Profile
+    >>>
+    >>> async with fresh_container(profile=Profile.TEST) as test_container:
+    ...     service = test_container.resolve(UserService)
+    ...     # Test with isolated container
 
 For more information, see the README and documentation.
 """

--- a/python/dioxide/container.py
+++ b/python/dioxide/container.py
@@ -258,7 +258,7 @@ Testing Example:
         # Tests run in milliseconds, no network calls, fully isolated
 
 Global Container Instance:
-    For most applications, use the global singleton container::
+    For simple scripts and CLI tools, use the global singleton container::
 
         from dioxide import container, Profile
 
@@ -273,6 +273,13 @@ Global Container Instance:
             # All @lifecycle components initialized
             await app.run()
         # All @lifecycle components disposed
+
+    .. note::
+
+        For testing, libraries, and larger applications, prefer **instance containers**
+        (``Container()``) over the global container. Instance containers provide better
+        isolation and are easier to test. See the user guide for details:
+        :doc:`/docs/user_guide/container_patterns`
 
 Manual Registration Example:
     Register components without decorators::

--- a/python/dioxide/testing.py
+++ b/python/dioxide/testing.py
@@ -3,6 +3,13 @@
 This module provides helpers for writing tests with dioxide, making it easy
 to create isolated test containers with fresh state.
 
+Instance containers (created via ``Container()`` or ``fresh_container()``) are the
+**recommended pattern for testing**. Each container instance has its own singleton
+cache, ensuring complete test isolation without state leakage.
+
+For guidance on when to use instance containers vs the global container, see
+the Container Patterns guide: :doc:`/docs/user_guide/container_patterns`
+
 Pytest Plugin Usage:
     Add the following to your ``conftest.py`` to enable dioxide pytest fixtures::
 


### PR DESCRIPTION
## Summary
- Added comprehensive user guide on container patterns (`docs/user_guide/container_patterns.md`)
- Updated README with "Container Patterns: Global vs Instance" section
- Changed primary recommendation to instance containers for better testability
- Updated docstrings in container.py and testing.py

## Test plan
- [x] All 457 tests pass
- [x] Documentation builds successfully
- [x] Examples are consistent and accurate

Fixes #313