### PR TITLE
test: Add scope tests for @service decorator

### DIFF
--- a/python/dioxide/services.py
+++ b/python/dioxide/services.py
@@ -27,11 +27,16 @@ When to Use @service:
         |-- NO  --> Probably @service
 
 Key Characteristics:
-    - **Singleton scope**: One shared instance across the application
+    - **Configurable scope**: SINGLETON (default), FACTORY, or REQUEST scope
     - **Profile-agnostic**: Available in ALL profiles (production, test, development)
     - **Depends on ports**: Services depend on Protocols/ABCs, not concrete implementations
     - **Pure business logic**: No knowledge of databases, APIs, or infrastructure
     - **Constructor injection**: Dependencies resolved from __init__ type hints
+
+Scope Options:
+    - **@service** or **@service(scope=Scope.SINGLETON)**: One shared instance (default)
+    - **@service(scope=Scope.FACTORY)**: New instance on every resolve()
+    - **@service(scope=Scope.REQUEST)**: One instance per request scope
 
 In hexagonal architecture, services form the hexagon's center - the core domain
 that is isolated from external concerns. They depend on ports (abstractions), and
@@ -176,8 +181,9 @@ def service(
     They are available in all profiles (production, test, development) and
     support automatic dependency injection.
 
-    This is a specialized form of @component that:
+    Key characteristics:
     - Uses SINGLETON scope by default (one shared instance)
+    - Can use FACTORY scope for fresh instances per resolution
     - Can use REQUEST scope for per-request instances
     - Does not require profile specification (available everywhere)
     - Represents core domain logic in hexagonal architecture
@@ -200,6 +206,19 @@ def service(
             ... class NotificationService:
             ...     def __init__(self, email: EmailService):
             ...         self.email = email
+
+        Factory-scoped service (new instance each time):
+            >>> from dioxide import service, Scope
+            >>>
+            >>> @service(scope=Scope.FACTORY)
+            ... class TransactionContext:
+            ...     def __init__(self):
+            ...         self.transaction_id = str(uuid.uuid4())
+            >>>
+            >>> # Each resolve() returns a fresh instance:
+            >>> ctx1 = container.resolve(TransactionContext)
+            >>> ctx2 = container.resolve(TransactionContext)
+            >>> assert ctx1 is not ctx2
 
         Request-scoped service:
             >>> from dioxide import service, Scope

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,13 +1,15 @@
 """Tests for @service decorator.
 
 The @service decorator is used for core domain logic that:
-- Is a singleton (one shared instance)
+- Is a singleton by default (one shared instance)
+- Can use FACTORY scope for fresh instances per resolution
 - Available in ALL profiles (doesn't vary by environment)
 - Supports constructor-based dependency injection
 """
 
 from dioxide import (
     Container,
+    Scope,
     _get_registered_components,
     service,
 )
@@ -106,3 +108,96 @@ class DescribeServiceDecorator:
 
         instance = container.resolve(ServiceWithoutInit)
         assert isinstance(instance, ServiceWithoutInit)
+
+
+class DescribeServiceScope:
+    """Tests for @service decorator scope behavior."""
+
+    def it_defaults_to_singleton_scope(self) -> None:
+        """Service without explicit scope defaults to SINGLETON."""
+
+        @service
+        class DefaultScopeService:
+            pass
+
+        assert hasattr(DefaultScopeService, '__dioxide_scope__')
+        assert DefaultScopeService.__dioxide_scope__ == Scope.SINGLETON
+
+    def it_accepts_explicit_singleton_scope(self) -> None:
+        """Service can explicitly specify SINGLETON scope."""
+
+        @service(scope=Scope.SINGLETON)
+        class ExplicitSingletonService:
+            pass
+
+        assert ExplicitSingletonService.__dioxide_scope__ == Scope.SINGLETON
+
+    def it_accepts_factory_scope(self) -> None:
+        """Service can specify FACTORY scope for per-resolution instances."""
+
+        @service(scope=Scope.FACTORY)
+        class FactoryScopeService:
+            pass
+
+        assert FactoryScopeService.__dioxide_scope__ == Scope.FACTORY
+
+    def it_returns_same_instance_for_singleton_scope(self) -> None:
+        """SINGLETON scope returns same instance on each resolve."""
+
+        @service(scope=Scope.SINGLETON)
+        class SingletonService:
+            pass
+
+        container = Container()
+        container.scan()
+
+        instance1 = container.resolve(SingletonService)
+        instance2 = container.resolve(SingletonService)
+
+        assert instance1 is instance2
+
+    def it_returns_new_instance_for_factory_scope(self) -> None:
+        """FACTORY scope returns new instance on each resolve."""
+
+        @service(scope=Scope.FACTORY)
+        class FactoryService:
+            pass
+
+        container = Container()
+        container.scan()
+
+        instance1 = container.resolve(FactoryService)
+        instance2 = container.resolve(FactoryService)
+        instance3 = container.resolve(FactoryService)
+
+        assert instance1 is not instance2
+        assert instance2 is not instance3
+        assert instance1 is not instance3
+
+    def it_preserves_factory_instance_independence(self) -> None:
+        """FACTORY scope instances have independent state."""
+
+        @service(scope=Scope.FACTORY)
+        class StatefulFactoryService:
+            instance_count = 0
+
+            def __init__(self) -> None:
+                StatefulFactoryService.instance_count += 1
+                self.id = StatefulFactoryService.instance_count
+
+        container = Container()
+        container.scan()
+
+        instance1 = container.resolve(StatefulFactoryService)
+        instance2 = container.resolve(StatefulFactoryService)
+
+        assert instance1.id != instance2.id
+
+    def it_accepts_request_scope(self) -> None:
+        """Service can specify REQUEST scope for per-scope instances."""
+
+        @service(scope=Scope.REQUEST)
+        class RequestScopeService:
+            pass
+
+        assert RequestScopeService.__dioxide_scope__ == Scope.REQUEST


### PR DESCRIPTION
## Summary
- Verified that `@service(scope=...)` already works with all scope options
- Added 7 new tests covering SINGLETON, FACTORY, and REQUEST scopes
- Updated services.py docstrings to document scope behavior
- Removed reference to non-existent `@component` decorator

## Findings
- `@service` defaults to `Scope.SINGLETON`
- `@service(scope=Scope.FACTORY)` creates new instances on each resolve
- `@service(scope=Scope.REQUEST)` scopes to request context

## Test plan
- [x] All 464 tests pass (7 new)
- [x] Scope behavior verified with explicit tests

Fixes #315