### PR TITLE
feat: add rich context constructors to exception classes

### DIFF
--- a/python/dioxide/exceptions.py
+++ b/python/dioxide/exceptions.py
@@ -669,8 +669,12 @@ class ServiceNotFoundError(ResolutionError):
                 param_name, param_type, reason = failed_dependency
                 param_type_name = param_type.__name__ if hasattr(param_type, '__name__') else str(param_type)
                 lines.append(f'  Missing dependency: {param_name}: {param_type_name} ({reason})')
-            elif dependencies:
-                lines.append(f'  Dependencies: {", ".join(dependencies)}')
+            elif dependencies is not None:
+                # dependencies=[] means registered with no deps, dependencies=['...'] has deps
+                if dependencies:
+                    lines.append(f'  Dependencies: {", ".join(dependencies)}')
+                else:
+                    lines.append('  No dependencies')
             else:
                 lines.append('  Not registered (missing @service decorator)')
 


### PR DESCRIPTION
## Summary
- Added structured constructor parameters to exception classes for rich error context
- `AdapterNotFoundError`: accepts port, profile, available_adapters
- `ServiceNotFoundError`: accepts service, profile, dependencies, failed_dependency
- `ScopeError`: accepts component, required_scope
- `CaptiveDependencyError`: accepts parent, parent_scope, child, child_scope

## Changes
This PR enhances the exception classes to accept structured data that gets stored in the exception's `context` attribute. This enables:
- Programmatic access to error context for debugging tools and IDEs
- Automatic message generation from structured data
- Backward compatibility with existing string-based usage

The string output remains terse (1-3 lines) as per issue #312, but full context is available via `error.context`.

## Test plan
- [x] All 565 existing tests pass
- [x] Added 24 new tests in `test_rich_error_context.py`
- [x] Coverage at 94.71% overall, 100% for exceptions.py
- [x] mypy passes with no issues
- [x] ruff check/format passes

Fixes #344