### PR TITLE
fix: add retry loop with exponential backoff for PyPI verification

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -547,18 +547,32 @@ jobs:
       contents: read
 
     steps:
-      - name: Wait for PyPI to update
-        run: sleep 60
-
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
-      - name: Verify package on PyPI
+      - name: Verify installation from PyPI
         run: |
-          pip install dioxide==${{ needs.validate.outputs.version }}
-          python -c "import dioxide; print(f'Successfully installed version {dioxide.__version__}')"
+          VERSION="${{ needs.validate.outputs.version }}"
+          MAX_ATTEMPTS=10
+          DELAY=30
+
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            echo "Attempt $i/$MAX_ATTEMPTS: checking for dioxide==$VERSION on PyPI..."
+            if pip install --dry-run dioxide==$VERSION 2>/dev/null; then
+              echo "Package found on PyPI, installing..."
+              pip install dioxide==$VERSION
+              python -c "import dioxide; print(f'Successfully verified version {dioxide.__version__}')"
+              exit 0
+            fi
+            echo "Package not yet available, waiting ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY + 15))  # Increase delay each attempt
+          done
+
+          echo "Package not found after $MAX_ATTEMPTS attempts"
+          exit 1
 
       - name: Create deployment summary
         run: |


### PR DESCRIPTION
## Summary

- Replace the single 60-second sleep with a robust retry loop for PyPI verification
- Uses exponential backoff: starts at 30s, increases by 15s each attempt (up to 10 attempts)
- Uses `pip install --dry-run` to check package availability before actual install
- Provides clear logging of each attempt and graceful failure after retries exhausted

## Problem

The "Verify PyPI Publication" step fails intermittently because it tries to install the newly published package before PyPI has fully indexed it. The previous implementation had only a 60-second sleep which isn't enough for PyPI CDN propagation.

## Solution

The retry loop:
- Attempts up to 10 times
- Uses exponential backoff (30s, 45s, 60s, 75s, 90s, 105s, 120s, 135s, 150s, 165s)
- Total maximum wait time: ~16 minutes if all retries are needed
- Logs each attempt clearly
- Exits successfully when package is found
- Fails gracefully after all retries exhausted

Fixes #364