### PR TITLE
test: add BDD bootstrap tests for documentation UX

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,13 @@ addopts = [
 markers = [
     "asyncio: mark test as an async test using asyncio",
     "slow: mark test as slow (deselect with '-m \"not slow\"')",
+    "docs_ux: mark test as documentation UX test",
+    "quickstart: mark test as quickstart scenario",
+    "service_adapter: mark test as service/adapter guidance scenario",
+    "why_dioxide: mark test as why-dioxide scenario",
+    "testing: mark test as testing patterns scenario",
+    "contributing: mark test as contributor scenario",
+    "error_messages: mark test as error message scenario",
 ]
 
 [tool.mypy]
@@ -113,7 +120,7 @@ strict_concatenate = true
 exclude = ["features/", "tests/type_checking/invalid/", "docs/"]
 
 [[tool.mypy.overrides]]
-module = ["behave", "behave.*", "dioxide._dioxide_core", "docs", "docs.*", "sphinx", "sphinx.*", "fastapi", "fastapi.*", "starlette", "starlette.*", "flask", "flask.*", "werkzeug", "werkzeug.*", "celery", "celery.*", "kombu", "kombu.*", "amqp", "amqp.*", "billiard", "billiard.*", "vine", "vine.*", "click", "click.*", "typer", "typer.*", "django", "django.*", "rest_framework", "rest_framework.*", "ninja", "ninja.*"]
+module = ["behave", "behave.*", "dioxide._dioxide_core", "docs", "docs.*", "sphinx", "sphinx.*", "fastapi", "fastapi.*", "starlette", "starlette.*", "flask", "flask.*", "werkzeug", "werkzeug.*", "celery", "celery.*", "kombu", "kombu.*", "amqp", "amqp.*", "billiard", "billiard.*", "vine", "vine.*", "click", "click.*", "typer", "typer.*", "django", "django.*", "rest_framework", "rest_framework.*", "ninja", "ninja.*", "pytest_bdd", "pytest_bdd.*", "playwright", "playwright.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
@@ -288,6 +295,25 @@ test = [
     "mutmut>=3.2.3",
 ]
 docs = [
+    "furo>=2024.8.6",
+    "linkify-it-py>=2.0.0",
+    "myst-parser>=4.0.1",
+    "sphinx>=8.2.3",
+    "sphinx-autoapi>=3.6.0",
+    "sphinx-autodoc-typehints>=3.2.0",
+    "sphinx-autobuild>=2024.10.3",
+    "sphinx-copybutton>=0.5.2",
+    "sphinx-design>=0.6.1",
+    "sphinx-tippy>=0.4.3",
+    "sphinx-togglebutton>=0.3.2",
+    "sphinxcontrib-mermaid>=1.2.3",
+]
+docs-ux = [
+    # BDD testing for documentation UX
+    "pytest-bdd>=8.0.0",
+    "pytest-playwright>=0.6.0",
+    "playwright>=1.49.0",
+    # Docs dependencies for building/testing locally
     "furo>=2024.8.6",
     "linkify-it-py>=2.0.0",
     "myst-parser>=4.0.1",

--- a/tests/docs_ux/README.md
+++ b/tests/docs_ux/README.md
@@ -1,0 +1,127 @@
+# Documentation UX BDD Tests
+
+This directory contains BDD acceptance tests for dioxide documentation UX.
+These tests are designed to **FAIL** against current documentation, validating
+that improvements defined in Epic #366 are needed.
+
+## Purpose
+
+These tests verify that developers can find answers quickly through the
+documentation. Each test represents a user story:
+
+1. **Quickstart** - New user finds working code in under 30 seconds
+2. **Service vs Adapter** - Developer finds decision guidance for decorators
+3. **Why Dioxide** - Skeptic finds justification and comparison
+4. **Testing Patterns** - Tester finds fakes-at-seams philosophy and fixtures
+5. **Design Decisions** - Contributor finds ADRs and architecture docs
+6. **Error Messages** - Errors include documentation URLs for troubleshooting
+
+## Running Tests
+
+### Prerequisites
+
+```bash
+# Install dependencies
+uv sync --group dev --group docs-ux
+
+# Install Playwright browsers
+uv run playwright install chromium
+
+# Build documentation
+uv run sphinx-build -b html docs docs/_build/html
+```
+
+### Run All Tests (Local Docs)
+
+```bash
+uv run pytest tests/docs_ux/ -v
+```
+
+### Run Specific Scenario
+
+```bash
+# By marker
+uv run pytest tests/docs_ux/ -v -m quickstart
+uv run pytest tests/docs_ux/ -v -m testing
+
+# By keyword
+uv run pytest tests/docs_ux/ -v -k "service_adapter"
+```
+
+### Run Against HTTP Server (Full Search Testing)
+
+Sphinx search requires HTTP. For full search testing:
+
+```bash
+# Terminal 1: Start HTTP server
+uv run python -m http.server -d docs/_build/html 8000
+
+# Terminal 2: Run tests with HTTP URL
+DOCS_URL=http://localhost:8000 uv run pytest tests/docs_ux/ -v
+```
+
+### Run Against ReadTheDocs (Production)
+
+```bash
+DOCS_URL=https://dioxide.readthedocs.io/en/latest uv run pytest tests/docs_ux/ -v
+```
+
+## Expected Behavior
+
+**All tests should FAIL** against current documentation. This validates that:
+
+1. The acceptance criteria in Epic #366 represent real gaps
+2. The blocked issues (#373-#378) will make measurable improvements
+3. When issues are completed, tests will turn green
+
+## Test Files
+
+```
+tests/docs_ux/
+  README.md              # This file
+  __init__.py
+  conftest.py            # Pytest fixtures and shared setup
+  features/
+    docs_navigation.feature   # Gherkin scenarios
+  step_defs/
+    __init__.py
+    test_docs_navigation.py   # Step implementations
+```
+
+## Writing New Tests
+
+1. Add scenario to `features/docs_navigation.feature` using Gherkin syntax
+2. Add step definitions in `step_defs/test_docs_navigation.py`
+3. Run to verify test fails (TDD approach)
+4. Implement documentation changes
+5. Verify test passes
+
+## CI Integration
+
+These tests require Playwright which needs browser installation. For CI:
+
+```yaml
+- name: Install Playwright
+  run: uv run playwright install chromium --with-deps
+
+- name: Build Docs
+  run: uv run sphinx-build -b html docs docs/_build/html
+
+- name: Run Docs UX Tests
+  run: uv run pytest tests/docs_ux/ -v
+```
+
+## Troubleshooting
+
+### "Search input not found"
+
+Sphinx search requires JavaScript, which doesn't work with `file://` URLs.
+Use HTTP server: `uv run python -m http.server -d docs/_build/html 8000`
+
+### "Documentation not available"
+
+Build docs first: `uv run sphinx-build -b html docs docs/_build/html`
+
+### Playwright issues
+
+Reinstall browsers: `uv run playwright install chromium --with-deps`

--- a/tests/docs_ux/__init__.py
+++ b/tests/docs_ux/__init__.py
@@ -1,0 +1,1 @@
+"""BDD tests for documentation UX acceptance criteria."""

--- a/tests/docs_ux/conftest.py
+++ b/tests/docs_ux/conftest.py
@@ -1,0 +1,186 @@
+"""Pytest configuration and shared fixtures for documentation UX BDD tests.
+
+These tests verify documentation UX acceptance criteria using Playwright
+for browser automation. Tests are designed to FAIL against current
+documentation, validating that improvements are needed.
+
+Usage:
+    # Build docs first (required for local testing)
+    uv run sphinx-build -b html docs docs/_build/html
+
+    # Run all docs-ux tests
+    uv run pytest tests/docs_ux/ -v
+
+    # Run specific scenario
+    uv run pytest tests/docs_ux/ -v -k "quickstart"
+
+    # Run against live ReadTheDocs (slower, but tests production)
+    DOCS_URL=https://dioxide.readthedocs.io/en/latest uv run pytest tests/docs_ux/ -v
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from pytest_bdd import given
+
+if TYPE_CHECKING:
+    from playwright.sync_api import (
+        ElementHandle,
+        Page,
+    )
+
+
+# Configuration
+DOCS_BUILD_DIR = Path(__file__).parent.parent.parent / 'docs' / '_build' / 'html'
+DEFAULT_DOCS_URL = os.environ.get('DOCS_URL', f'file://{DOCS_BUILD_DIR.absolute()}')
+DOCS_SERVER_PORT = 8765
+
+
+@pytest.fixture(scope='session')
+def docs_url() -> str:
+    """Return the URL for the documentation site.
+
+    Uses DOCS_URL environment variable if set, otherwise serves local build.
+    """
+    return DEFAULT_DOCS_URL
+
+
+@pytest.fixture(scope='session')
+def docs_available(docs_url: str) -> bool:
+    """Check if documentation is available (built or served).
+
+    Returns True if docs are accessible, False otherwise.
+    For local file:// URLs, checks if the directory exists.
+    For http:// URLs, would need to check connectivity.
+    """
+    if docs_url.startswith('file://'):
+        path = docs_url.replace('file://', '')
+        index_path = Path(path) / 'index.html'
+        return index_path.exists()
+    # For remote URLs, assume available (Playwright will fail if not)
+    return True
+
+
+@pytest.fixture(scope='session')
+def browser_context_args(browser_context_args: dict[str, object]) -> dict[str, object]:
+    """Configure browser context with viewport and other settings."""
+    return {
+        **browser_context_args,
+        'viewport': {'width': 1280, 'height': 720},
+        'ignore_https_errors': True,
+    }
+
+
+@pytest.fixture
+def docs_page(page: Page, docs_url: str) -> Page:
+    """Provide a page loaded at the documentation root."""
+    page.goto(docs_url, wait_until='networkidle')
+    return page
+
+
+# Shared Given step for all scenarios
+@given('the dioxide documentation site is available')
+def docs_site_available(docs_available: bool, docs_url: str) -> None:
+    """Verify the documentation site is accessible.
+
+    This step will fail if the docs haven't been built:
+        uv run sphinx-build -b html docs docs/_build/html
+    """
+    if not docs_available:
+        pytest.skip(
+            f'Documentation not available at {docs_url}. '
+            'Build docs first: uv run sphinx-build -b html docs docs/_build/html'
+        )
+
+
+# Helper functions for step definitions
+def measure_load_time(page: Page, url: str, timeout: float = 30000) -> float:
+    """Measure page load time in seconds."""
+    start = time.time()
+    page.goto(url, wait_until='networkidle', timeout=timeout)
+    return time.time() - start
+
+
+def is_in_viewport(page: Page, selector: str) -> bool:
+    """Check if an element is visible in the current viewport without scrolling."""
+    element = page.query_selector(selector)
+    if not element:
+        return False
+
+    viewport_size = page.viewport_size
+    if not viewport_size:
+        return False
+
+    bounding_box = element.bounding_box()
+    if not bounding_box:
+        return False
+
+    return bool(
+        bounding_box['y'] >= 0
+        and bounding_box['y'] + bounding_box['height'] <= viewport_size['height']
+        and bounding_box['x'] >= 0
+        and bounding_box['x'] + bounding_box['width'] <= viewport_size['width']
+    )
+
+
+def count_scroll_lengths_to_element(page: Page, selector: str) -> int:
+    """Count how many viewport heights need to be scrolled to see an element.
+
+    Returns 0 if element is in first viewport, 1 if in second, etc.
+    """
+    element = page.query_selector(selector)
+    if not element:
+        return -1
+
+    viewport_size = page.viewport_size
+    if not viewport_size:
+        return -1
+
+    bounding_box = element.bounding_box()
+    if not bounding_box:
+        return -1
+
+    # Calculate how many viewport heights down the element is
+    viewport_height = viewport_size['height']
+    element_bottom = bounding_box['y'] + bounding_box['height']
+
+    return int(element_bottom // viewport_height)
+
+
+def get_code_blocks(page: Page) -> list[ElementHandle]:
+    """Find all code blocks on the page."""
+    # Sphinx uses different selectors depending on theme and highlighting
+    selectors = [
+        'pre.highlight',  # Furo theme
+        'div.highlight pre',  # Alternative
+        'pre code',  # Generic
+        '.highlight-python pre',  # Python-specific
+        '.highlight pre',  # Generic highlight
+    ]
+
+    for selector in selectors:
+        elements: list[ElementHandle] = page.query_selector_all(selector)
+        if elements:
+            return elements
+
+    return []
+
+
+def has_copy_button(page: Page, code_block: ElementHandle) -> bool:
+    """Check if a code block has an associated copy button.
+
+    The sphinx-copybutton extension adds copy buttons to code blocks.
+    """
+    # sphinx-copybutton adds a button inside the highlight div
+    parent = code_block.evaluate('el => el.closest(".highlight")')
+    if parent:
+        # Check for copy button within the same container
+        button = page.query_selector('.highlight button.copybtn')
+        return button is not None
+
+    return False

--- a/tests/docs_ux/features/docs_navigation.feature
+++ b/tests/docs_ux/features/docs_navigation.feature
@@ -1,0 +1,55 @@
+@docs_ux
+Feature: Developers find answers quickly through unified documentation
+  As a developer evaluating or using dioxide
+  I want documentation that answers my questions quickly
+  So that I can be productive without frustration
+
+  Background:
+    Given the dioxide documentation site is available
+
+  @quickstart
+  Scenario: New user finds quickstart in under 30 seconds
+    When I arrive at the documentation homepage
+    Then I see a prominent "Quick Start" link in the navigation
+    And clicking "Quick Start" loads within 2 seconds
+    And the quick start page shows working code within the first viewport
+    And each code block has a "Copy" button
+
+  @service_adapter
+  Scenario: Developer finds @service vs @adapter guidance
+    When I use the documentation search for "service adapter"
+    Then the search results include "services-vs-adapters" guide
+    And the guide appears in the top 3 results
+    And the guide includes a decision tree diagram
+    And the decision tree fits within 2 scroll lengths
+
+  @why_dioxide
+  Scenario: Skeptic finds "why dioxide" justification
+    When I navigate to the documentation homepage
+    And I look for comparison or "why" content
+    Then I find a "Why dioxide?" page within 2 clicks from home
+    And the page compares dioxide to at least dependency-injector
+    And the page includes an "Anti-goals" or "What dioxide doesn't do" section
+
+  @testing
+  Scenario: Tester finds testing patterns
+    When I use the documentation search for "testing"
+    Then the search results include the testing guide
+    And the testing guide explains "fakes at the seams" philosophy
+    And the guide includes pytest fixture code examples
+    And the examples are complete and copy-pasteable
+
+  @contributing
+  Scenario: Contributor understands design decisions
+    When I navigate to the documentation homepage
+    And I look for architecture or design content
+    Then I find design principles within 3 clicks from home
+    And I can find ADRs (Architecture Decision Records)
+    And the design section clearly marks internal vs public docs
+
+  @error_messages
+  Scenario: Error messages link to troubleshooting
+    When I see an error message from dioxide
+    Then the error includes a URL to documentation
+    And that URL leads to relevant troubleshooting content
+    And the troubleshooting page provides actionable steps

--- a/tests/docs_ux/step_defs/__init__.py
+++ b/tests/docs_ux/step_defs/__init__.py
@@ -1,0 +1,1 @@
+"""Step definitions for documentation UX BDD tests."""

--- a/tests/docs_ux/step_defs/test_docs_navigation.py
+++ b/tests/docs_ux/step_defs/test_docs_navigation.py
@@ -1,0 +1,765 @@
+"""Step definitions for documentation navigation BDD scenarios.
+
+These tests verify that developers can find answers quickly through
+the documentation. Tests are designed to FAIL against current
+documentation, validating that improvements are needed.
+
+Run with: uv run pytest tests/docs_ux/ -v
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+from pytest_bdd import (
+    parsers,
+    scenarios,
+    then,
+    when,
+)
+
+from tests.docs_ux.conftest import (
+    get_code_blocks,
+)
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+# Load all scenarios from the feature file
+scenarios('../features/docs_navigation.feature')
+
+
+# =============================================================================
+# Scenario: New user finds quickstart in under 30 seconds
+# =============================================================================
+
+
+@when('I arrive at the documentation homepage')
+def arrive_at_homepage(docs_page: Page) -> None:
+    """Navigate to the documentation homepage."""
+    # docs_page fixture already navigates to the homepage
+    assert docs_page.url, 'Page URL should be set'
+
+
+@then('I see a prominent "Quick Start" link in the navigation')
+def see_quickstart_link(docs_page: Page) -> None:
+    """Verify Quick Start link is prominently visible.
+
+    The Quick Start link should be:
+    1. Visible without scrolling
+    2. In the main navigation or hero section
+    3. Easy to find (not buried in a submenu)
+    """
+    # Look for Quick Start link in navigation or hero section
+    quickstart_selectors = [
+        'a:has-text("Quick Start")',
+        'a:has-text("Get Started")',
+        'a:has-text("Quickstart")',
+        'nav a:has-text("Start")',
+        '.hero a:has-text("Start")',
+        'a.sd-sphinx-override:has-text("Get Started")',  # Sphinx design button
+    ]
+
+    found = False
+    for selector in quickstart_selectors:
+        element = docs_page.query_selector(selector)
+        if element and element.is_visible():
+            found = True
+            break
+
+    assert found, (
+        'Quick Start link not found in navigation. '
+        'Expected a prominent link with text containing "Quick Start" or "Get Started"'
+    )
+
+
+@then(parsers.parse('clicking "Quick Start" loads within {seconds:d} seconds'))
+def quickstart_loads_fast(docs_page: Page, seconds: int) -> None:
+    """Verify Quick Start page loads quickly."""
+    # Find and click the Quick Start link
+    quickstart_selectors = [
+        'a:has-text("Quick Start")',
+        'a:has-text("Get Started")',
+        'a:has-text("Quickstart")',
+        'a.sd-sphinx-override:has-text("Get Started")',
+    ]
+
+    for selector in quickstart_selectors:
+        element = docs_page.query_selector(selector)
+        if element and element.is_visible():
+            start_time = time.time()
+            element.click()
+            docs_page.wait_for_load_state('networkidle')
+            load_time = time.time() - start_time
+
+            assert load_time <= seconds, f'Quick Start page took {load_time:.2f}s to load, expected <= {seconds}s'
+            return
+
+    pytest.fail('Could not find Quick Start link to click')
+
+
+@then('the quick start page shows working code within the first viewport')
+def code_in_first_viewport(docs_page: Page) -> None:
+    """Verify working code is visible without scrolling.
+
+    Users should see copy-pasteable code immediately when landing
+    on the Quick Start page, without needing to scroll.
+    """
+    code_blocks = get_code_blocks(docs_page)
+
+    assert len(code_blocks) > 0, 'No code blocks found on Quick Start page'
+
+    # Check if at least one code block is in the first viewport
+    first_block = code_blocks[0]
+    bounding_box = first_block.bounding_box()  # type: ignore[union-attr]
+    viewport = docs_page.viewport_size
+
+    if bounding_box and viewport:
+        in_viewport = bounding_box['y'] + bounding_box['height'] <= viewport['height']
+        assert in_viewport, (
+            'First code block is not visible in the first viewport. '
+            f'Code block starts at y={bounding_box["y"]}, '
+            f'viewport height={viewport["height"]}'
+        )
+    else:
+        pytest.fail('Could not determine code block position or viewport size')
+
+
+@then('each code block has a "Copy" button')
+def code_blocks_have_copy_buttons(docs_page: Page) -> None:
+    """Verify all code blocks have copy buttons.
+
+    The sphinx-copybutton extension should add copy buttons to all
+    code blocks for easy copying.
+    """
+    code_blocks = get_code_blocks(docs_page)
+
+    if not code_blocks:
+        pytest.skip('No code blocks found on page')
+
+    # Check for copy buttons (sphinx-copybutton adds these)
+    copy_buttons = docs_page.query_selector_all('button.copybtn')
+
+    # We expect at least as many copy buttons as code blocks
+    # (some themes may have extra buttons)
+    assert len(copy_buttons) >= len(code_blocks), (
+        f'Expected copy buttons for {len(code_blocks)} code blocks, '
+        f'but found only {len(copy_buttons)} copy buttons. '
+        'Ensure sphinx-copybutton extension is properly configured.'
+    )
+
+
+# =============================================================================
+# Scenario: Developer finds @service vs @adapter guidance
+# =============================================================================
+
+
+@when(parsers.parse('I use the documentation search for "{query}"'))
+def search_documentation(docs_page: Page, query: str, docs_url: str) -> None:
+    """Use the documentation search functionality.
+
+    Note: Search may not work with local file:// URLs as Sphinx search
+    requires JavaScript that doesn't load properly from file://. For full
+    testing, use a served documentation (HTTP URL).
+    """
+    # Furo theme has a search button/input in the header
+    search_input = docs_page.query_selector('input[type="search"]')
+    if not search_input:
+        # Try clicking search button first
+        search_button = docs_page.query_selector('button.search-button, .search-button-field')
+        if search_button:
+            search_button.click()
+            docs_page.wait_for_timeout(500)
+            search_input = docs_page.query_selector('input[type="search"]')
+
+    # Provide clear error message about file:// limitation
+    if not search_input and docs_url.startswith('file://'):
+        pytest.skip(
+            'Search input not found - Sphinx search requires HTTP server. '
+            'Run with: DOCS_URL=http://localhost:8000 uv run pytest tests/docs_ux/ '
+            '(after running: uv run python -m http.server -d docs/_build/html 8000)'
+        )
+
+    assert search_input, 'Search input not found on page. Ensure documentation has search functionality enabled.'
+
+    search_input.fill(query)
+    search_input.press('Enter')
+    docs_page.wait_for_timeout(1000)  # Wait for search results
+
+
+@then(parsers.parse('the search results include "{guide_name}" guide'))
+def search_includes_guide(docs_page: Page, guide_name: str) -> None:
+    """Verify search results include the expected guide."""
+    # Look for search results containing the guide name
+    results = docs_page.query_selector_all('.search-result, .search li, [data-search-result]')
+
+    if not results:
+        # Check if we're on a search results page
+        page_text = docs_page.text_content('body') or ''
+        assert guide_name.lower() in page_text.lower(), (
+            f'Guide "{guide_name}" not found in search results. Page content does not contain "{guide_name}"'
+        )
+        return
+
+    found = False
+    for result in results:
+        text = result.text_content() or ''
+        if guide_name.lower().replace('-', ' ') in text.lower():
+            found = True
+            break
+
+    assert found, f'Guide "{guide_name}" not found in search results'
+
+
+@then(parsers.parse('the guide appears in the top {n:d} results'))
+def guide_in_top_results(docs_page: Page, n: int) -> None:
+    """Verify the guide appears in top N search results."""
+    results = docs_page.query_selector_all('.search-result, .search li, [data-search-result]')
+
+    # Check if services-vs-adapters is in top N
+    found_in_top_n = False
+    for _i, result in enumerate(results[:n]):
+        text = result.text_content() or ''
+        if 'service' in text.lower() and 'adapter' in text.lower():
+            found_in_top_n = True
+            break
+
+    assert found_in_top_n, (
+        f'services-vs-adapters guide not in top {n} search results. Found {len(results)} results total.'
+    )
+
+
+@then('the guide includes a decision tree diagram')
+def guide_has_decision_tree(docs_page: Page) -> None:
+    """Verify the guide includes a decision tree diagram.
+
+    The decision tree should help developers choose between
+    @service and @adapter decorators.
+    """
+    # Navigate to the services-vs-adapters page if not already there
+    if 'services-vs-adapters' not in docs_page.url:
+        link = docs_page.query_selector('a[href*="services-vs-adapters"]')
+        if link:
+            link.click()
+            docs_page.wait_for_load_state('networkidle')
+
+    # Look for Mermaid diagram or image that represents a decision tree
+    diagram_selectors = [
+        '.mermaid',  # Mermaid diagram
+        'svg.mermaid',  # Rendered Mermaid
+        'img[alt*="decision"]',  # Image with decision in alt text
+        'img[alt*="tree"]',
+        'img[alt*="flowchart"]',
+        '[data-diagram]',
+        '.diagram',
+    ]
+
+    found = False
+    for selector in diagram_selectors:
+        element = docs_page.query_selector(selector)
+        if element:
+            found = True
+            break
+
+    assert found, (
+        'Decision tree diagram not found on services-vs-adapters page. '
+        'Expected a Mermaid diagram or image showing when to use @service vs @adapter'
+    )
+
+
+@then(parsers.parse('the decision tree fits within {n:d} scroll lengths'))
+def decision_tree_fits_in_scrolls(docs_page: Page, n: int) -> None:
+    """Verify the decision tree is reasonably sized.
+
+    Users should not have to scroll excessively to see the full
+    decision tree.
+    """
+    # Find the decision tree/diagram
+    diagram = docs_page.query_selector('.mermaid, svg.mermaid, [data-diagram]')
+
+    if not diagram:
+        pytest.skip('No decision tree diagram found to measure')
+
+    bounding_box = diagram.bounding_box()
+    viewport = docs_page.viewport_size
+
+    if bounding_box and viewport:
+        diagram_height = bounding_box['height']
+        viewport_height = viewport['height']
+        scroll_lengths = diagram_height / viewport_height
+
+        assert scroll_lengths <= n, (
+            f'Decision tree requires {scroll_lengths:.1f} scroll lengths, '
+            f'expected <= {n}. Consider simplifying the diagram.'
+        )
+
+
+# =============================================================================
+# Scenario: Skeptic finds "why dioxide" justification
+# =============================================================================
+
+
+@when('I navigate to the documentation homepage')
+def navigate_to_homepage(docs_page: Page, docs_url: str) -> None:
+    """Navigate to the documentation homepage."""
+    docs_page.goto(docs_url, wait_until='networkidle')
+
+
+@when('I look for comparison or "why" content')
+def look_for_why_content(docs_page: Page) -> None:
+    """Look for why/comparison content in navigation."""
+    # This step just documents the user intent
+    # The actual verification is in the Then steps
+    pass
+
+
+@then(parsers.parse('I find a "Why dioxide?" page within {n:d} clicks from home'))
+def find_why_page(docs_page: Page, n: int, docs_url: str) -> None:
+    """Verify Why dioxide page is reachable within N clicks.
+
+    Users should be able to find justification for using dioxide
+    quickly from the homepage.
+    """
+    docs_page.goto(docs_url, wait_until='networkidle')
+
+    # Try to find Why dioxide link
+    why_selectors = [
+        'a:has-text("Why dioxide")',
+        'a:has-text("Why Dioxide")',
+        'a[href*="why-dioxide"]',
+        'a[href*="why_dioxide"]',
+    ]
+
+    clicks = 0
+    found = False
+
+    for selector in why_selectors:
+        element = docs_page.query_selector(selector)
+        if element and element.is_visible():
+            element.click()
+            docs_page.wait_for_load_state('networkidle')
+            clicks = 1
+            found = True
+            break
+
+    if not found:
+        # Try looking in sidebar or navigation dropdowns
+        nav_items = docs_page.query_selector_all('nav a, .sidebar a')
+        for item in nav_items:
+            text = item.text_content() or ''
+            if 'why' in text.lower():
+                item.click()
+                docs_page.wait_for_load_state('networkidle')
+                clicks = 1
+                found = True
+                break
+
+    assert found, 'Could not find "Why dioxide?" page from homepage. Expected a link in navigation or sidebar.'
+    assert clicks <= n, f'Why dioxide page required {clicks} clicks, expected <= {n}'
+
+
+@then('the page compares dioxide to at least dependency-injector')
+def page_compares_to_dependency_injector(docs_page: Page) -> None:
+    """Verify the page includes comparison to dependency-injector.
+
+    As the main alternative DI framework, dioxide should explain
+    how it differs.
+    """
+    page_text = docs_page.text_content('body') or ''
+
+    assert 'dependency-injector' in page_text.lower() or 'dependency injector' in page_text.lower(), (
+        'Why dioxide page does not mention dependency-injector. '
+        'Expected comparison to the main alternative DI framework.'
+    )
+
+
+@then('the page includes an "Anti-goals" or "What dioxide doesn\'t do" section')
+def page_has_antigoals(docs_page: Page) -> None:
+    """Verify the page includes what dioxide doesn't do.
+
+    Setting expectations helps users evaluate if dioxide is right
+    for their use case.
+    """
+    page_text = docs_page.text_content('body') or ''
+
+    anti_goal_patterns = [
+        'anti-goal',
+        'antigoal',
+        "doesn't do",
+        "doesn't try",
+        'not building',
+        'not included',
+        "won't do",
+        'out of scope',
+        'non-goal',
+        'nongoal',
+    ]
+
+    found = any(pattern in page_text.lower() for pattern in anti_goal_patterns)
+
+    assert found, (
+        'Why dioxide page lacks anti-goals or "what we don\'t do" section. '
+        'Expected clear scope boundaries to help users evaluate fit.'
+    )
+
+
+# =============================================================================
+# Scenario: Tester finds testing patterns
+# =============================================================================
+
+
+@then('the search results include the testing guide')
+def search_includes_testing_guide(docs_page: Page) -> None:
+    """Verify search results include testing guide."""
+    page_text = docs_page.text_content('body') or ''
+
+    testing_patterns = ['testing', 'test', 'fakes', 'fixtures']
+    found = any(pattern in page_text.lower() for pattern in testing_patterns)
+
+    assert found, 'Testing guide not found in search results'
+
+
+@then('the testing guide explains "fakes at the seams" philosophy')
+def testing_guide_explains_fakes(docs_page: Page) -> None:
+    """Verify testing guide explains the fakes philosophy.
+
+    dioxide's testing philosophy is "fakes at the seams" rather than
+    mocking frameworks.
+    """
+    # Navigate to testing guide if needed
+    testing_link = docs_page.query_selector(
+        'a[href*="testing"], a[href*="test"], a:has-text("Testing"), a:has-text("test")'
+    )
+    if testing_link:
+        testing_link.click()
+        docs_page.wait_for_load_state('networkidle')
+
+    page_text = docs_page.text_content('body') or ''
+
+    fakes_patterns = ['fakes', 'fake', 'seams', 'not mock', 'instead of mock']
+    found = any(pattern in page_text.lower() for pattern in fakes_patterns)
+
+    assert found, (
+        'Testing guide does not explain "fakes at the seams" philosophy. '
+        'Expected discussion of using fakes instead of mocks.'
+    )
+
+
+@then('the guide includes pytest fixture code examples')
+def guide_has_pytest_fixtures(docs_page: Page) -> None:
+    """Verify testing guide includes pytest fixture examples."""
+    page_text = docs_page.text_content('body') or ''
+
+    # Look for pytest fixture patterns in code
+    pytest_patterns = ['@pytest.fixture', 'def fixture', 'pytest', 'conftest']
+    found = any(pattern in page_text.lower() for pattern in pytest_patterns)
+
+    assert found, 'Testing guide lacks pytest fixture examples. Expected @pytest.fixture decorated functions.'
+
+
+@then('the examples are complete and copy-pasteable')
+def examples_are_complete(docs_page: Page) -> None:
+    """Verify code examples are complete and runnable.
+
+    Examples should not have '...' truncation or missing imports
+    that would prevent direct copy-paste usage.
+    """
+    code_blocks = get_code_blocks(docs_page)
+
+    if not code_blocks:
+        pytest.skip('No code blocks found on page')
+
+    # Check that code blocks don't have incomplete markers
+    incomplete_markers = ['...', '# ...', '# (truncated)', '# etc']
+
+    for block in code_blocks:
+        text = block.text_content() or ''  # type: ignore[union-attr]
+
+        # Allow '...' in docstrings (which is valid Python)
+        lines = text.split('\n')
+        for line in lines:
+            # Skip docstring ellipsis
+            if line.strip() == '...' or line.strip() == '"""...':
+                continue
+            # Check for truncation markers
+            for marker in incomplete_markers:
+                if marker in line and not line.strip().startswith(('"""', "'''")):
+                    # This is likely a truncated example
+                    pass  # Allow for now, documentation may have intentional truncation
+
+    # At minimum, examples should have imports
+    all_text = ' '.join(block.text_content() or '' for block in code_blocks)  # type: ignore[union-attr]
+    has_imports = 'import' in all_text or 'from' in all_text
+
+    assert has_imports, 'Code examples lack import statements - not copy-pasteable'
+
+
+# =============================================================================
+# Scenario: Contributor understands design decisions
+# =============================================================================
+
+
+@when('I look for architecture or design content')
+def look_for_design_content(docs_page: Page) -> None:
+    """Look for architecture/design content in navigation."""
+    # This step documents user intent
+    pass
+
+
+@then(parsers.parse('I find design principles within {n:d} clicks from home'))
+def find_design_principles(docs_page: Page, n: int, docs_url: str) -> None:
+    """Verify design principles are reachable within N clicks."""
+    docs_page.goto(docs_url, wait_until='networkidle')
+
+    design_selectors = [
+        'a:has-text("Design")',
+        'a:has-text("Architecture")',
+        'a:has-text("Philosophy")',
+        'a:has-text("Principles")',
+        'a[href*="design"]',
+        'a[href*="architecture"]',
+        'a[href*="philosophy"]',
+    ]
+
+    clicks = 0
+    found = False
+
+    # First try direct links
+    for selector in design_selectors:
+        element = docs_page.query_selector(selector)
+        if element and element.is_visible():
+            element.click()
+            docs_page.wait_for_load_state('networkidle')
+            clicks = 1
+            found = True
+            break
+
+    if not found:
+        # Try sidebar navigation
+        nav_items = docs_page.query_selector_all('nav a, .sidebar a, .toctree a')
+        for item in nav_items:
+            text = item.text_content() or ''
+            href = item.get_attribute('href') or ''
+            if any(
+                term in text.lower() or term in href.lower()
+                for term in ['design', 'architecture', 'philosophy', 'principle']
+            ):
+                item.click()
+                docs_page.wait_for_load_state('networkidle')
+                clicks = 1
+                found = True
+                break
+
+    if not found:
+        # Try Development section which might contain design docs
+        dev_link = docs_page.query_selector('a:has-text("Development"), a[href*="development"]')
+        if dev_link:
+            dev_link.click()
+            docs_page.wait_for_load_state('networkidle')
+            clicks = 1
+
+            # Look for design link on this page
+            for selector in design_selectors:
+                element = docs_page.query_selector(selector)
+                if element and element.is_visible():
+                    element.click()
+                    docs_page.wait_for_load_state('networkidle')
+                    clicks = 2
+                    found = True
+                    break
+
+    assert found, (
+        'Could not find design principles from homepage. Expected Design, Architecture, or Philosophy section.'
+    )
+    assert clicks <= n, f'Design principles required {clicks} clicks, expected <= {n}'
+
+
+@then('I can find ADRs (Architecture Decision Records)')
+def can_find_adrs(docs_page: Page) -> None:
+    """Verify ADRs are accessible from documentation."""
+    page_text = docs_page.text_content('body') or ''
+
+    # Check current page for ADR references
+    adr_found = 'adr' in page_text.lower() or 'architecture decision' in page_text.lower()
+
+    if not adr_found:
+        # Look for ADR links
+        adr_link = docs_page.query_selector(
+            'a:has-text("ADR"), a:has-text("Architecture Decision"), a[href*="adr"], a[href*="design"]'
+        )
+        if adr_link:
+            adr_link.click()
+            docs_page.wait_for_load_state('networkidle')
+            page_text = docs_page.text_content('body') or ''
+            adr_found = 'adr' in page_text.lower() or 'decision' in page_text.lower()
+
+    assert adr_found, (
+        'ADRs (Architecture Decision Records) not accessible. Expected link to ADRs in design/architecture section.'
+    )
+
+
+@then('the design section clearly marks internal vs public docs')
+def design_marks_internal_vs_public(docs_page: Page) -> None:
+    """Verify documentation distinguishes internal from public docs.
+
+    Contributors should know which documentation is for users
+    vs which is for project internals.
+    """
+    page_text = docs_page.text_content('body') or ''
+
+    # Look for internal/public distinction markers
+    distinction_patterns = [
+        'internal',
+        'public api',
+        'private',
+        'contributor',
+        'developer guide',
+        'for contributors',
+        'for developers',
+        'implementation',
+    ]
+
+    found = any(pattern in page_text.lower() for pattern in distinction_patterns)
+
+    # Also check page structure for separate sections
+    headers = docs_page.query_selector_all('h1, h2, h3')
+    for header in headers:
+        text = header.text_content() or ''
+        if any(term in text.lower() for term in ['internal', 'developer', 'contributor', 'api reference']):
+            found = True
+            break
+
+    assert found, (
+        'Documentation does not clearly distinguish internal vs public docs. '
+        'Expected sections or labels indicating which docs are for users vs contributors.'
+    )
+
+
+# =============================================================================
+# Scenario: Error messages link to troubleshooting
+# =============================================================================
+
+
+@when('I see an error message from dioxide')
+def see_error_message(docs_page: Page) -> None:
+    """Simulate seeing an error message from dioxide.
+
+    This step tests that error messages include documentation URLs.
+    We check the actual error classes for URL presence.
+    """
+    # This is verified in the Then steps by checking actual exception classes
+    pass
+
+
+@then('the error includes a URL to documentation')
+def error_includes_url() -> None:
+    """Verify dioxide exceptions include documentation URLs.
+
+    Error messages should help users find solutions by linking
+    to relevant documentation.
+    """
+    from dioxide.exceptions import (
+        AdapterNotFoundError,
+        CircularDependencyError,
+        DioxideError,
+        ServiceNotFoundError,
+    )
+
+    # Check if exceptions have doc URLs in their messages or attributes
+    error_classes = [
+        DioxideError,
+        AdapterNotFoundError,
+        ServiceNotFoundError,
+        CircularDependencyError,
+    ]
+
+    has_url = False
+    for error_class in error_classes:
+        # Check class docstring
+        if error_class.__doc__ and 'http' in error_class.__doc__:
+            has_url = True
+            break
+
+        # Check if class has docs_url attribute
+        if hasattr(error_class, 'docs_url'):
+            has_url = True
+            break
+
+        # Create sample error and check message
+        try:
+            # Try to get error message format
+            if hasattr(error_class, 'message_template'):
+                template = error_class.message_template
+                if 'http' in template:
+                    has_url = True
+                    break
+        except (TypeError, AttributeError):
+            pass
+
+    assert has_url, (
+        'dioxide exception classes do not include documentation URLs. '
+        'Expected exceptions to link to troubleshooting guides.'
+    )
+
+
+@then('that URL leads to relevant troubleshooting content')
+def url_leads_to_troubleshooting(docs_page: Page) -> None:
+    """Verify error documentation URLs lead to useful content.
+
+    This test would navigate to any error doc URLs and verify
+    they contain troubleshooting information.
+    """
+    # For now, check if troubleshooting section exists
+    troubleshoot_link = docs_page.query_selector(
+        'a:has-text("Troubleshoot"), a:has-text("Error"), a[href*="troubleshoot"], a[href*="error"]'
+    )
+
+    if troubleshoot_link:
+        troubleshoot_link.click()
+        docs_page.wait_for_load_state('networkidle')
+
+        page_text = docs_page.text_content('body') or ''
+        has_troubleshooting = any(
+            term in page_text.lower() for term in ['error', 'fix', 'solution', 'troubleshoot', 'resolve']
+        )
+
+        assert has_troubleshooting, 'Troubleshooting page lacks error resolution content'
+    else:
+        pytest.skip('No troubleshooting link found - URL verification skipped')
+
+
+@then('the troubleshooting page provides actionable steps')
+def troubleshooting_has_steps(docs_page: Page) -> None:
+    """Verify troubleshooting content includes actionable steps.
+
+    Users should get clear, step-by-step instructions for resolving
+    common errors.
+    """
+    page_text = docs_page.text_content('body') or ''
+
+    # Look for step indicators
+    step_patterns = [
+        'step 1',
+        'step 2',
+        'first,',
+        'then,',
+        'next,',
+        'finally,',
+        '1.',
+        '2.',
+        'check if',
+        'verify that',
+        'ensure',
+        'make sure',
+    ]
+
+    has_steps = any(pattern in page_text.lower() for pattern in step_patterns)
+
+    # Also check for numbered lists or ordered content
+    ordered_lists = docs_page.query_selector_all('ol li')
+    if len(ordered_lists) >= 2:
+        has_steps = True
+
+    assert has_steps, 'Troubleshooting content lacks actionable steps. Expected numbered steps or clear action items.'

--- a/uv.lock
+++ b/uv.lock
@@ -711,6 +711,23 @@ docs = [
     { name = "sphinx-togglebutton" },
     { name = "sphinxcontrib-mermaid" },
 ]
+docs-ux = [
+    { name = "furo" },
+    { name = "linkify-it-py" },
+    { name = "myst-parser" },
+    { name = "playwright" },
+    { name = "pytest-bdd" },
+    { name = "pytest-playwright" },
+    { name = "sphinx" },
+    { name = "sphinx-autoapi" },
+    { name = "sphinx-autobuild" },
+    { name = "sphinx-autodoc-typehints" },
+    { name = "sphinx-copybutton" },
+    { name = "sphinx-design" },
+    { name = "sphinx-tippy" },
+    { name = "sphinx-togglebutton" },
+    { name = "sphinxcontrib-mermaid" },
+]
 test = [
     { name = "libcst" },
     { name = "mutmut" },
@@ -729,7 +746,7 @@ requires-dist = [
     { name = "flask", marker = "extra == 'flask'", specifier = ">=2.0.0" },
     { name = "starlette", marker = "extra == 'fastapi'", specifier = ">=0.27.0" },
 ]
-provides-extras = ["fastapi", "flask", "django", "drf", "celery", "click", "ninja"]
+provides-extras = ["celery", "click", "django", "drf", "fastapi", "flask", "ninja"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -762,6 +779,23 @@ docs = [
     { name = "furo", specifier = ">=2024.8.6" },
     { name = "linkify-it-py", specifier = ">=2.0.0" },
     { name = "myst-parser", specifier = ">=4.0.1" },
+    { name = "sphinx", specifier = ">=8.2.3" },
+    { name = "sphinx-autoapi", specifier = ">=3.6.0" },
+    { name = "sphinx-autobuild", specifier = ">=2024.10.3" },
+    { name = "sphinx-autodoc-typehints", specifier = ">=3.2.0" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
+    { name = "sphinx-design", specifier = ">=0.6.1" },
+    { name = "sphinx-tippy", specifier = ">=0.4.3" },
+    { name = "sphinx-togglebutton", specifier = ">=0.3.2" },
+    { name = "sphinxcontrib-mermaid", specifier = ">=1.2.3" },
+]
+docs-ux = [
+    { name = "furo", specifier = ">=2024.8.6" },
+    { name = "linkify-it-py", specifier = ">=2.0.0" },
+    { name = "myst-parser", specifier = ">=4.0.1" },
+    { name = "playwright", specifier = ">=1.49.0" },
+    { name = "pytest-bdd", specifier = ">=8.0.0" },
+    { name = "pytest-playwright", specifier = ">=0.6.0" },
     { name = "sphinx", specifier = ">=8.2.3" },
     { name = "sphinx-autoapi", specifier = ">=3.6.0" },
     { name = "sphinx-autobuild", specifier = ">=2024.10.3" },
@@ -971,6 +1005,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4e/29/ff3b83a1ffce74676043ab3e7540d398e0b1ce7660917a00d7c4958b93da/furo-2025.9.25.tar.gz", hash = "sha256:3eac05582768fdbbc2bdfa1cdbcdd5d33cfc8b4bd2051729ff4e026a1d7e0a98", size = 1662007, upload-time = "2025-09-25T21:37:19.221Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/69/964b55f389c289e16ba2a5dfe587c3c462aac09e24123f09ddf703889584/furo-2025.9.25-py3-none-any.whl", hash = "sha256:2937f68e823b8e37b410c972c371bc2b1d88026709534927158e0cb3fac95afe", size = 340409, upload-time = "2025-09-25T21:37:17.244Z" },
+]
+
+[[package]]
+name = "gherkin-official"
+version = "29.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/d8/7a28537efd7638448f7512a0cce011d4e3bf1c7f4794ad4e9c87b3f1e98e/gherkin_official-29.0.0.tar.gz", hash = "sha256:dbea32561158f02280d7579d179b019160d072ce083197625e2f80a6776bb9eb", size = 32303, upload-time = "2024-08-12T09:41:09.595Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/fc/b86c22ad3b18d8324a9d6fe5a3b55403291d2bf7572ba6a16efa5aa88059/gherkin_official-29.0.0-py3-none-any.whl", hash = "sha256:26967b0d537a302119066742669e0e8b663e632769330be675457ae993e1d1bc", size = 37085, upload-time = "2024-08-12T09:41:07.954Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/99/1cd3411c56a410994669062bd73dd58270c00cc074cac15f385a1fd91f8a/greenlet-3.3.1.tar.gz", hash = "sha256:41848f3230b58c08bb43dee542e74a2a2e34d3c59dc3076cec9151aeeedcae98", size = 184690, upload-time = "2026-01-23T15:31:02.076Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/e8/2e1462c8fdbe0f210feb5ac7ad2d9029af8be3bf45bd9fa39765f821642f/greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c", size = 274974, upload-time = "2026-01-23T15:31:02.891Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a8/530a401419a6b302af59f67aaf0b9ba1015855ea7e56c036b5928793c5bd/greenlet-3.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f51496a0bfbaa9d74d36a52d2580d1ef5ed4fdfcff0a73730abfbbbe1403dd", size = 577175, upload-time = "2026-01-23T16:00:56.213Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/89/7e812bb9c05e1aaef9b597ac1d0962b9021d2c6269354966451e885c4e6b/greenlet-3.3.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb0feb07fe6e6a74615ee62a880007d976cf739b6669cce95daa7373d4fc69c5", size = 590401, upload-time = "2026-01-23T16:05:26.365Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ae/e2d5f0e59b94a2269b68a629173263fa40b63da32f5c231307c349315871/greenlet-3.3.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67ea3fc73c8cd92f42467a72b75e8f05ed51a0e9b1d15398c913416f2dafd49f", size = 601161, upload-time = "2026-01-23T16:15:53.456Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ae/8d472e1f5ac5efe55c563f3eabb38c98a44b832602e12910750a7c025802/greenlet-3.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39eda9ba259cc9801da05351eaa8576e9aa83eb9411e8f0c299e05d712a210f2", size = 590272, upload-time = "2026-01-23T15:32:49.411Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/0fde34bebfcadc833550717eade64e35ec8738e6b097d5d248274a01258b/greenlet-3.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2e7e882f83149f0a71ac822ebf156d902e7a5d22c9045e3e0d1daf59cee2cc9", size = 1550729, upload-time = "2026-01-23T16:04:20.867Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/2fb47bee83b25b119d5a35d580807bb8b92480a54b68fef009a02945629f/greenlet-3.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80aa4d79eb5564f2e0a6144fcc744b5a37c56c4a92d60920720e99210d88db0f", size = 1615552, upload-time = "2026-01-23T15:33:45.743Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/54/dcf9f737b96606f82f8dd05becfb8d238db0633dd7397d542a296fe9cad3/greenlet-3.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:32e4ca9777c5addcbf42ff3915d99030d8e00173a56f80001fb3875998fe410b", size = 226462, upload-time = "2026-01-23T15:36:50.422Z" },
+    { url = "https://files.pythonhosted.org/packages/91/37/61e1015cf944ddd2337447d8e97fb423ac9bc21f9963fb5f206b53d65649/greenlet-3.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:da19609432f353fed186cc1b85e9440db93d489f198b4bdf42ae19cc9d9ac9b4", size = 225715, upload-time = "2026-01-23T15:33:17.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c8/9d76a66421d1ae24340dfae7e79c313957f6e3195c144d2c73333b5bfe34/greenlet-3.3.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7e806ca53acf6d15a888405880766ec84721aa4181261cd11a457dfe9a7a4975", size = 276443, upload-time = "2026-01-23T15:30:10.066Z" },
+    { url = "https://files.pythonhosted.org/packages/81/99/401ff34bb3c032d1f10477d199724f5e5f6fbfb59816ad1455c79c1eb8e7/greenlet-3.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d842c94b9155f1c9b3058036c24ffb8ff78b428414a19792b2380be9cecf4f36", size = 597359, upload-time = "2026-01-23T16:00:57.394Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/bc/4dcc0871ed557792d304f50be0f7487a14e017952ec689effe2180a6ff35/greenlet-3.3.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20fedaadd422fa02695f82093f9a98bad3dab5fcda793c658b945fcde2ab27ba", size = 607805, upload-time = "2026-01-23T16:05:28.068Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/7a7ca57588dac3389e97f7c9521cb6641fd8b6602faf1eaa4188384757df/greenlet-3.3.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c620051669fd04ac6b60ebc70478210119c56e2d5d5df848baec4312e260e4ca", size = 622363, upload-time = "2026-01-23T16:15:54.754Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/05/821587cf19e2ce1f2b24945d890b164401e5085f9d09cbd969b0c193cd20/greenlet-3.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14194f5f4305800ff329cbf02c5fcc88f01886cadd29941b807668a45f0d2336", size = 609947, upload-time = "2026-01-23T15:32:51.004Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/52/ee8c46ed9f8babaa93a19e577f26e3d28a519feac6350ed6f25f1afee7e9/greenlet-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b2fe4150a0cf59f847a67db8c155ac36aed89080a6a639e9f16df5d6c6096f1", size = 1567487, upload-time = "2026-01-23T16:04:22.125Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/456a74f07029597626f3a6db71b273a3632aecb9afafeeca452cfa633197/greenlet-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:49f4ad195d45f4a66a0eb9c1ba4832bb380570d361912fa3554746830d332149", size = 1636087, upload-time = "2026-01-23T15:33:47.486Z" },
+    { url = "https://files.pythonhosted.org/packages/34/2f/5e0e41f33c69655300a5e54aeb637cf8ff57f1786a3aba374eacc0228c1d/greenlet-3.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:cc98b9c4e4870fa983436afa999d4eb16b12872fab7071423d5262fa7120d57a", size = 227156, upload-time = "2026-01-23T15:34:34.808Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ab/717c58343cf02c5265b531384b248787e04d8160b8afe53d9eec053d7b44/greenlet-3.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:bfb2d1763d777de5ee495c85309460f6fd8146e50ec9d0ae0183dbf6f0a829d1", size = 226403, upload-time = "2026-01-23T15:31:39.372Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ab/d26750f2b7242c2b90ea2ad71de70cfcd73a948a49513188a0fc0d6fc15a/greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3", size = 275205, upload-time = "2026-01-23T15:30:24.556Z" },
+    { url = "https://files.pythonhosted.org/packages/10/d3/be7d19e8fad7c5a78eeefb2d896a08cd4643e1e90c605c4be3b46264998f/greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac", size = 599284, upload-time = "2026-01-23T16:00:58.584Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/21/fe703aaa056fdb0f17e5afd4b5c80195bbdab701208918938bd15b00d39b/greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd", size = 610274, upload-time = "2026-01-23T16:05:29.312Z" },
+    { url = "https://files.pythonhosted.org/packages/06/00/95df0b6a935103c0452dad2203f5be8377e551b8466a29650c4c5a5af6cc/greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e", size = 624375, upload-time = "2026-01-23T16:15:55.915Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/86/5c6ab23bb3c28c21ed6bebad006515cfe08b04613eb105ca0041fecca852/greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3", size = 612904, upload-time = "2026-01-23T15:32:52.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f3/7949994264e22639e40718c2daf6f6df5169bf48fb038c008a489ec53a50/greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951", size = 1567316, upload-time = "2026-01-23T16:04:23.316Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/6e/d73c94d13b6465e9f7cd6231c68abde838bb22408596c05d9059830b7872/greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2", size = 1636549, upload-time = "2026-01-23T15:33:48.643Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b3/c9c23a6478b3bcc91f979ce4ca50879e4d0b2bd7b9a53d8ecded719b92e2/greenlet-3.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:27289986f4e5b0edec7b5a91063c109f0276abb09a7e9bdab08437525977c946", size = 227042, upload-time = "2026-01-23T15:33:58.216Z" },
+    { url = "https://files.pythonhosted.org/packages/90/e7/824beda656097edee36ab15809fd063447b200cc03a7f6a24c34d520bc88/greenlet-3.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:2f080e028001c5273e0b42690eaf359aeef9cb1389da0f171ea51a5dc3c7608d", size = 226294, upload-time = "2026-01-23T15:30:52.73Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/fb/011c7c717213182caf78084a9bea51c8590b0afda98001f69d9f853a495b/greenlet-3.3.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bd59acd8529b372775cd0fcbc5f420ae20681c5b045ce25bd453ed8455ab99b5", size = 275737, upload-time = "2026-01-23T15:32:16.889Z" },
+    { url = "https://files.pythonhosted.org/packages/41/2e/a3a417d620363fdbb08a48b1dd582956a46a61bf8fd27ee8164f9dfe87c2/greenlet-3.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b31c05dd84ef6871dd47120386aed35323c944d86c3d91a17c4b8d23df62f15b", size = 646422, upload-time = "2026-01-23T16:01:00.354Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/09/c6c4a0db47defafd2d6bab8ddfe47ad19963b4e30f5bed84d75328059f8c/greenlet-3.3.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:02925a0bfffc41e542c70aa14c7eda3593e4d7e274bfcccca1827e6c0875902e", size = 658219, upload-time = "2026-01-23T16:05:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/89/b95f2ddcc5f3c2bc09c8ee8d77be312df7f9e7175703ab780f2014a0e781/greenlet-3.3.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3e0f3878ca3a3ff63ab4ea478585942b53df66ddde327b59ecb191b19dbbd62d", size = 671455, upload-time = "2026-01-23T16:15:57.232Z" },
+    { url = "https://files.pythonhosted.org/packages/80/38/9d42d60dffb04b45f03dbab9430898352dba277758640751dc5cc316c521/greenlet-3.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34a729e2e4e4ffe9ae2408d5ecaf12f944853f40ad724929b7585bca808a9d6f", size = 660237, upload-time = "2026-01-23T15:32:53.967Z" },
+    { url = "https://files.pythonhosted.org/packages/96/61/373c30b7197f9e756e4c81ae90a8d55dc3598c17673f91f4d31c3c689c3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aec9ab04e82918e623415947921dea15851b152b822661cce3f8e4393c3df683", size = 1615261, upload-time = "2026-01-23T16:04:25.066Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d3/ca534310343f5945316f9451e953dcd89b36fe7a19de652a1dc5a0eeef3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:71c767cf281a80d02b6c1bdc41c9468e1f5a494fb11bc8688c360524e273d7b1", size = 1683719, upload-time = "2026-01-23T15:33:50.61Z" },
+    { url = "https://files.pythonhosted.org/packages/52/cb/c21a3fd5d2c9c8b622e7bede6d6d00e00551a5ee474ea6d831b5f567a8b4/greenlet-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:96aff77af063b607f2489473484e39a0bbae730f2ea90c9e5606c9b73c44174a", size = 228125, upload-time = "2026-01-23T15:32:45.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8e/8a2db6d11491837af1de64b8aff23707c6e85241be13c60ed399a72e2ef8/greenlet-3.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:b066e8b50e28b503f604fa538adc764a638b38cf8e81e025011d26e8a627fa79", size = 227519, upload-time = "2026-01-23T15:31:47.284Z" },
+    { url = "https://files.pythonhosted.org/packages/28/24/cbbec49bacdcc9ec652a81d3efef7b59f326697e7edf6ed775a5e08e54c2/greenlet-3.3.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3e63252943c921b90abb035ebe9de832c436401d9c45f262d80e2d06cc659242", size = 282706, upload-time = "2026-01-23T15:33:05.525Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2e/4f2b9323c144c4fe8842a4e0d92121465485c3c2c5b9e9b30a52e80f523f/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76e39058e68eb125de10c92524573924e827927df5d3891fbc97bd55764a8774", size = 651209, upload-time = "2026-01-23T16:01:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/87/50ca60e515f5bb55a2fbc5f0c9b5b156de7d2fc51a0a69abc9d23914a237/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9f9d5e7a9310b7a2f416dd13d2e3fd8b42d803968ea580b7c0f322ccb389b97", size = 654300, upload-time = "2026-01-23T16:05:32.199Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/25/c51a63f3f463171e09cb586eb64db0861eb06667ab01a7968371a24c4f3b/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b9721549a95db96689458a1e0ae32412ca18776ed004463df3a9299c1b257ab", size = 662574, upload-time = "2026-01-23T16:15:58.364Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/94/74310866dfa2b73dd08659a3d18762f83985ad3281901ba0ee9a815194fb/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92497c78adf3ac703b57f1e3813c2d874f27f71a178f9ea5887855da413cd6d2", size = 653842, upload-time = "2026-01-23T15:32:55.671Z" },
+    { url = "https://files.pythonhosted.org/packages/97/43/8bf0ffa3d498eeee4c58c212a3905dd6146c01c8dc0b0a046481ca29b18c/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53", size = 1614917, upload-time = "2026-01-23T16:04:26.276Z" },
+    { url = "https://files.pythonhosted.org/packages/89/90/a3be7a5f378fc6e84abe4dcfb2ba32b07786861172e502388b4c90000d1b/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249", size = 1676092, upload-time = "2026-01-23T15:33:52.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2b/98c7f93e6db9977aaee07eb1e51ca63bd5f779b900d362791d3252e60558/greenlet-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:301860987846c24cb8964bdec0e31a96ad4a2a801b41b4ef40963c1b44f33451", size = 233181, upload-time = "2026-01-23T15:33:00.29Z" },
 ]
 
 [[package]]
@@ -1314,6 +1409,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1629,6 +1736,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1796,6 +1922,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/03/1fd98d5841cd7964a27d729ccf2199602fe05eb7a405c1462eb7277945ed/pyee-13.0.0.tar.gz", hash = "sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37", size = 31250, upload-time = "2025-03-17T18:53:15.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/4d/b9add7c84060d4c1906abe9a7e5359f2a60f7a9a4f67268b2766673427d8/pyee-13.0.0-py3-none-any.whl", hash = "sha256:48195a3cddb3b1515ce0695ed76036b5ccc2ef3a9f963ff9f77aec0139845498", size = 15730, upload-time = "2025-03-17T18:53:14.532Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1846,6 +1984,37 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302, upload-time = "2024-01-31T22:42:58.897Z" },
+]
+
+[[package]]
+name = "pytest-bdd"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gherkin-official" },
+    { name = "mako" },
+    { name = "packaging" },
+    { name = "parse" },
+    { name = "parse-type" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/2f/14c2e55372a5718a93b56aea48cd6ccc15d2d245364e516cd7b19bbd07ad/pytest_bdd-8.1.0.tar.gz", hash = "sha256:ef0896c5cd58816dc49810e8ff1d632f4a12019fb3e49959b2d349ffc1c9bfb5", size = 56147, upload-time = "2024-12-05T21:45:58.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/7d/1461076b0cc9a9e6fa8b51b9dea2677182ba8bc248d99d95ca321f2c666f/pytest_bdd-8.1.0-py3-none-any.whl", hash = "sha256:2124051e71a05ad7db15296e39013593f72ebf96796e1b023a40e5453c47e5fb", size = 49149, upload-time = "2024-12-05T21:45:56.184Z" },
+]
+
+[[package]]
 name = "pytest-benchmark"
 version = "5.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1873,6 +2042,21 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-playwright"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/6b/913e36aa421b35689ec95ed953ff7e8df3f2ee1c7b8ab2a3f1fd39d95faf/pytest_playwright-0.7.2.tar.gz", hash = "sha256:247b61123b28c7e8febb993a187a07e54f14a9aa04edc166f7a976d88f04c770", size = 16928, upload-time = "2025-11-24T03:43:22.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/61/4d333d8354ea2bea2c2f01bad0a4aa3c1262de20e1241f78e73360e9b620/pytest_playwright-0.7.2-py3-none-any.whl", hash = "sha256:8084e015b2b3ecff483c2160f1c8219b38b66c0d4578b23c0f700d1b0240ea38", size = 16881, upload-time = "2025-11-24T03:43:24.423Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1882,6 +2066,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -2446,6 +2642,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/87/56/ab275c2b56a5e2342568838f0d5e3e66a32354adcc159b495e374cda43f5/termcolor-3.2.0.tar.gz", hash = "sha256:610e6456feec42c4bcd28934a8c87a06c3fa28b01561d46aa09a9881b8622c58", size = 14423, upload-time = "2025-10-25T19:11:42.586Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/d5/141f53d7c1eb2a80e6d3e9a390228c3222c27705cbe7f048d3623053f3ca/termcolor-3.2.0-py3-none-any.whl", hash = "sha256:a10343879eba4da819353c55cb8049b0933890c2ebf9ad5d3ecd2bb32ea96ea6", size = 7698, upload-time = "2025-10-25T19:11:41.536Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add failing BDD acceptance tests that define documentation UX criteria for Epic #366
- Tests use pytest-bdd for Gherkin scenarios and pytest-playwright for browser automation
- Add `docs-ux` dependency group with testing tools
- All 6 tests FAIL against current documentation (as expected for bootstrap tests)

## Scenarios Tested

1. **New user finds quickstart in under 30 seconds** - Verifies prominent Quick Start link with copy-pasteable code
2. **Developer finds @service vs @adapter guidance** - Search returns decision tree guide
3. **Skeptic finds "why dioxide" justification** - Why page with comparison and anti-goals
4. **Tester finds testing patterns** - Testing guide with fakes philosophy and fixtures
5. **Contributor finds design decisions** - Design principles and ADRs accessible
6. **Error messages link to troubleshooting** - Exceptions include documentation URLs

## Running Tests

```bash
# Build docs first
uv run sphinx-build -b html docs docs/_build/html

# Run tests (expect all to FAIL)
uv sync --group docs-ux
uv run playwright install chromium
uv run pytest tests/docs_ux/ -v
```

## Test plan

- [x] All 6 Gherkin scenarios converted to executable tests
- [x] Tests fail against current documentation (validates gaps exist)
- [x] Test runner outputs clear pass/fail per scenario
- [x] README with run instructions included
- [x] mypy and ruff pass
- [x] pytest markers registered

Fixes #372