### PR TITLE
docs: add mission statement and anti-goals to why-dioxide comparison page

### DIFF
--- a/docs/why-dioxide.md
+++ b/docs/why-dioxide.md
@@ -424,7 +424,7 @@ dioxide uses Rust for performance. Installing from source requires a Rust toolch
 
 ## What dioxide is NOT
 
-These are not limitations to be fixed later. They are intentional design decisions.
+These are not limitations to be fixed later. They are intentional design decisions for the current major version and are unlikely to change.
 
 ### NOT a Framework
 


### PR DESCRIPTION
## Summary

- Added mission statement section: "Make the Dependency Inversion Principle feel inevitable"
- Updated feature comparison table with accurate claims:
  - Added Manual DI column as requested
  - Corrected that dependency-injector uses Cython (not pure Python)
  - Removed lagom (less common) in favor of Manual DI comparison
- Added comprehensive "What dioxide is NOT" anti-goals section:
  - NOT a framework (library that integrates into your architecture)
  - NOT a configuration system (use Pydantic Settings)
  - NOT trying to solve every DI pattern (constructor injection only)
  - NOT necessarily the fastest for raw lookups (honest about tradeoffs)
  - NOT feature-complete by design (small API surface is intentional)
- Added notes explaining comparison differences

## Test plan

- [x] Verified page is accessible from home in 1 click (Overview -> Why dioxide?)
- [x] Verified Sphinx build succeeds with no warnings related to why-dioxide
- [x] Verified comparison claims are factually accurate (researched dependency-injector and injector docs)
- [x] Verified anti-goals section is present and honest

Fixes #380