### PR TITLE
docs: add ASCII decision tree to decorator docstrings

### DIFF
--- a/python/dioxide/adapter.py
+++ b/python/dioxide/adapter.py
@@ -18,15 +18,28 @@ When to Use @adapter.for_():
     - The component should be the same across all environments (use @service)
     - You're not implementing a port interface
 
-    **Decision Tree**::
+    **Quick Decision Tree** (answer in 10 seconds)::
 
-        Do you need different implementations based on profile (test/prod/dev)?
-        |-- YES --> Define a Port (Protocol) + use @adapter.for_(Port, profile=...)
-        |-- NO  --> Use @service
-
-        Does this component talk to external systems (DB, network, filesystem)?
-        |-- YES --> Port + @adapter.for_() (allows faking in tests)
-        |-- NO  --> Probably @service
+        Which decorator should I use?
+                    |
+        Does it talk to external systems (DB, API, file, network)?
+                    |
+           +--------+--------+
+           |                 |
+          YES               NO
+           |                 |
+           v                 v
+        @adapter         Should different profiles use
+        .for_()          different implementations?
+        (this one!)           |
+                     +--------+--------+
+                     |                 |
+                    YES               NO
+                     |                 |
+                     v                 v
+                  @adapter         @service
+                  .for_()
+                  (this one!)
 
 In hexagonal architecture:
     - **Ports** are abstract interfaces (Protocols/ABCs) that define contracts
@@ -137,6 +150,7 @@ Container Resolution:
         email = test_container.resolve(EmailPort)  # Returns FakeEmailAdapter
 
 See Also:
+    - :doc:`/guides/choosing-decorators` - Visual decision tree with examples
     - :class:`dioxide.services.service` - For marking core domain logic
     - :class:`dioxide.profile_enum.Profile` - Extensible profile identifiers
     - :class:`dioxide.lifecycle.lifecycle` - For lifecycle management

--- a/python/dioxide/services.py
+++ b/python/dioxide/services.py
@@ -16,15 +16,27 @@ When to Use @service:
     Do NOT use @service if you need different implementations per profile.
     Use @adapter.for_() instead.
 
-    **Decision Tree**::
+    **Quick Decision Tree** (answer in 10 seconds)::
 
-        Is this core business logic that shouldn't change between environments?
-        |-- YES --> Use @service
-        |-- NO  --> Use @adapter.for_(Port, profile=...)
-
-        Does this component talk directly to external systems?
-        |-- YES --> Use @adapter.for_(Port, profile=...)
-        |-- NO  --> Probably @service
+        Which decorator should I use?
+                    |
+        Does it talk to external systems (DB, API, file, network)?
+                    |
+           +--------+--------+
+           |                 |
+          YES               NO
+           |                 |
+           v                 v
+        @adapter         Should different profiles use
+        .for_()          different implementations?
+                              |
+                     +--------+--------+
+                     |                 |
+                    YES               NO
+                     |                 |
+                     v                 v
+                  @adapter         @service
+                  .for_()          (this one!)
 
 Key Characteristics:
     - **Configurable scope**: SINGLETON (default), FACTORY, or REQUEST scope
@@ -141,6 +153,7 @@ Testing Example:
             assert saved_user is not None
 
 See Also:
+    - :doc:`/guides/choosing-decorators` - Visual decision tree with examples
     - :class:`dioxide.adapter.adapter` - For marking boundary implementations
     - :class:`dioxide.profile_enum.Profile` - Standard profile values
     - :class:`dioxide.container.Container` - For dependency resolution


### PR DESCRIPTION
## Summary

- Add visual ASCII decision tree to `@service` and `@adapter.for_()` module docstrings
- Make it easy for developers to answer "which decorator?" in 10 seconds from their IDE
- Add "See Also" reference to full `/guides/choosing-decorators` documentation

## The Decision Tree

Both decorators now include this ASCII flowchart in their module docstrings:

```
Which decorator should I use?
            |
Does it talk to external systems (DB, API, file, network)?
            |
   +--------+--------+
   |                 |
  YES               NO
   |                 |
   v                 v
@adapter         Should different profiles use
.for_()          different implementations?
                      |
             +--------+--------+
             |                 |
            YES               NO
             |                 |
             v                 v
          @adapter         @service
          .for_()
```

## Test Plan

- [x] Tests pass (`uv run pytest tests/`)
- [x] Linting passes (`ruff check`, `ruff format`, `mypy`)
- [x] Docstrings render correctly in `help(dioxide.services)` and module `__doc__`
- [x] Pre-commit hooks pass

Fixes #386