### PR TITLE
docs: serve llms.txt from Sphinx build output

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,6 +129,7 @@ myst_linkify_fuzzy_links = False  # Only match URLs with schema (http://, https:
 # -- Options for HTML output -------------------------------------------------
 html_theme = 'furo'
 html_static_path = ['_static']
+html_extra_path = ['../llms.txt']
 html_css_files = ['css/custom.css']
 
 # Furo theme options


### PR DESCRIPTION
## Summary
- Add `html_extra_path = ['../llms.txt']` to `docs/conf.py` so that the repo-root `llms.txt` is copied into the Sphinx HTML build output
- This makes the file accessible at `dioxide.readthedocs.io/en/latest/llms.txt` for AI tool discovery

## Test plan
- [x] Sphinx build succeeds (`uv run sphinx-build -b html docs docs/_build/html`)
- [x] `llms.txt` present in `docs/_build/html/llms.txt`

Fixes #428

Generated with [Claude Code](https://claude.ai/claude-code)