### PR TITLE
fix: Use importlib.metadata for dynamic __version__

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,10 +14,8 @@ if TYPE_CHECKING:
 sys.path.insert(0, str(Path('..').resolve()))
 
 # Import version from package
-# Version is synchronized across:
-# - python/dioxide/__init__.py (__version__ variable)
-# - Cargo.toml (package.version field)
-# - ReadTheDocs (builds for each git tag matching v*.*.*)
+# Version source of truth: Cargo.toml (package.version field)
+# dioxide.__version__ reads this via importlib.metadata at runtime
 import dioxide
 
 _version = dioxide.__version__

--- a/python/dioxide/__init__.py
+++ b/python/dioxide/__init__.py
@@ -50,6 +50,8 @@ Testing (fresh container per test - recommended):
 For more information, see the README and documentation.
 """
 
+from importlib.metadata import version as _metadata_version
+
 from ._registry import (
     _clear_registry,
     _get_registered_components,
@@ -76,7 +78,7 @@ from .scope import Scope
 from .services import service
 from .testing import fresh_container
 
-__version__ = '1.0.1'
+__version__ = _metadata_version('dioxide')
 __all__ = [
     'AdapterNotFoundError',
     'CaptiveDependencyError',


### PR DESCRIPTION
## Summary

- Replace stale hardcoded `__version__ = '1.0.1'` with dynamic `importlib.metadata.version('dioxide')` so the version always matches the installed package metadata from `Cargo.toml`
- Update `docs/conf.py` comment to reflect that version source of truth is `Cargo.toml`, read at runtime via `importlib.metadata`

## Test plan

- [x] `uv run python -c "import dioxide; print(dioxide.__version__)"` returns `2.0.1` (matches `Cargo.toml`)
- [x] All 703 tests pass (`uv run pytest tests/`)
- [x] Linting passes (`ruff check python/ && ruff format --check python/`)
- [x] Type checking passes (`mypy python/`)
- [x] Pre-commit hooks pass

Fixes #433

Generated with [Claude Code](https://claude.ai/claude-code)