### PR TITLE
feat: Hide Profile.ALL wildcard in string representations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,6 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "features/**/*.py" = ["S101", "PLC0415"]  # Allow assert, deferred imports in behave step definitions
 "tests/**/*.py" = ["S101", "B008", "PLC0415"]  # Allow assert, Inject() in defaults, local imports in tests
-"features/**/*.py" = ["PLC0415"]  # Allow local imports in behave step definitions
 "python/dioxide/container.py" = ["PLC0415"]  # Allow local imports in scan() to avoid circular dependencies
 "python/dioxide/decorators.py" = ["PLC0415"]  # Allow local imports to avoid circular dependencies
 "python/dioxide/fastapi.py" = ["PLC0415"]  # Allow local imports to avoid circular dependencies

--- a/python/dioxide/container.py
+++ b/python/dioxide/container.py
@@ -1296,14 +1296,14 @@ class Container:
         and developers can inspect container state in a REPL or debugger.
 
         Returns:
-            A string like ``Container(profile=Profile('production'), ports=5, services=3)``
+            A string like ``Container(profile=Profile.PRODUCTION, ports=5, services=3)``
             or ``Container(profile=None, ports=0, services=0)`` when no profile is set.
 
         Example:
             >>> from dioxide import Container, Profile
             >>> container = Container(profile=Profile.PRODUCTION)
             >>> repr(container)
-            "Container(profile=Profile('production'), ports=..., services=...)"
+            'Container(profile=Profile.PRODUCTION, ports=..., services=...)'
         """
         profile = self.active_profile
         profile_str = repr(profile) if profile is not None else 'None'
@@ -2836,12 +2836,12 @@ class ScopedContainer:
         so agents and developers can inspect scoped container state.
 
         Returns:
-            A string like ``ScopedContainer(profile=Profile('test'), parent=Container)``.
+            A string like ``ScopedContainer(profile=Profile.TEST, parent=Container)``.
 
         Example:
             >>> async with container.create_scope() as scope:
             ...     repr(scope)
-            "ScopedContainer(profile=Profile('test'), parent=Container)"
+            'ScopedContainer(profile=Profile.TEST, parent=Container)'
         """
         profile = self._parent.active_profile
         profile_str = repr(profile) if profile is not None else 'None'

--- a/tests/test_container_repr.py
+++ b/tests/test_container_repr.py
@@ -28,7 +28,7 @@ class DescribeContainerRepr:
 
         result = repr(container)
 
-        assert result == "Container(profile=Profile('test'), ports=0, services=0)"
+        assert result == 'Container(profile=Profile.TEST, ports=0, services=0)'
 
     def it_counts_adapters_registered_via_scan(self) -> None:
         class NotificationPort(Protocol):
@@ -82,7 +82,7 @@ class DescribeContainerRepr:
 
         result = repr(container)
 
-        assert "profile=Profile('production')" in result
+        assert 'profile=Profile.PRODUCTION' in result
 
     def it_shows_string_profile_as_profile_instance(self) -> None:
         container = Container()
@@ -90,7 +90,7 @@ class DescribeContainerRepr:
 
         result = repr(container)
 
-        assert "profile=Profile('staging')" in result
+        assert 'profile=Profile.STAGING' in result
 
     def it_shows_profile_all_wildcard(self) -> None:
         container = Container()
@@ -98,7 +98,7 @@ class DescribeContainerRepr:
 
         result = repr(container)
 
-        assert "profile=Profile('*')" in result
+        assert 'profile=Profile.ALL' in result
 
 
 class DescribeScopedContainerRepr:
@@ -110,7 +110,7 @@ class DescribeScopedContainerRepr:
 
         result = repr(scoped)
 
-        assert result == "ScopedContainer(profile=Profile('test'), parent=Container)"
+        assert result == 'ScopedContainer(profile=Profile.TEST, parent=Container)'
 
     def it_shows_no_profile_when_parent_has_none(self) -> None:
         container = Container()

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -93,22 +93,65 @@ class DescribeProfile:
             def accepts_profile(p: Profile) -> str:
                 return str(p)
 
-            # These should work at runtime (type checker validates statically)
-            assert accepts_profile(Profile.PRODUCTION) == 'production'
+            assert accepts_profile(Profile.PRODUCTION) == 'PRODUCTION'
             assert accepts_profile(Profile('custom')) == 'custom'
 
     class DescribeRepr:
         """String representation."""
 
-        def it_has_informative_repr(self) -> None:
-            """repr shows it's a Profile."""
-            assert repr(Profile.PRODUCTION) == "Profile('production')"
+        def it_shows_constant_name_for_builtin_profiles(self) -> None:
+            assert repr(Profile.PRODUCTION) == 'Profile.PRODUCTION'
+            assert repr(Profile.ALL) == 'Profile.ALL'
+
+        def it_shows_constructor_form_for_custom_profiles(self) -> None:
             assert repr(Profile('custom')) == "Profile('custom')"
 
-        def it_has_value_as_str(self) -> None:
-            """str returns the profile value."""
-            assert str(Profile.PRODUCTION) == 'production'
+        def it_returns_display_name_for_builtin_str(self) -> None:
+            assert str(Profile.PRODUCTION) == 'PRODUCTION'
+            assert str(Profile.ALL) == 'ALL'
+
+        def it_returns_value_for_custom_str(self) -> None:
             assert str(Profile('custom')) == 'custom'
+
+    class DescribeStringRepresentation:
+        """String representation hides implementation details (#387)."""
+
+        def it_returns_all_for_str_of_profile_all(self) -> None:
+            assert str(Profile.ALL) == 'ALL'
+
+        def it_hides_wildcard_in_f_string_formatting(self) -> None:
+            assert f'Profile is {Profile.ALL}' == 'Profile is ALL'
+
+        def it_shows_profile_all_in_repr(self) -> None:
+            assert repr(Profile.ALL) == 'Profile.ALL'
+
+        def it_shows_display_names_for_all_builtin_profiles_in_str(self) -> None:
+            assert str(Profile.PRODUCTION) == 'PRODUCTION'
+            assert str(Profile.TEST) == 'TEST'
+            assert str(Profile.DEVELOPMENT) == 'DEVELOPMENT'
+            assert str(Profile.STAGING) == 'STAGING'
+            assert str(Profile.CI) == 'CI'
+            assert str(Profile.ALL) == 'ALL'
+
+        def it_shows_constant_names_for_all_builtin_profiles_in_repr(self) -> None:
+            assert repr(Profile.PRODUCTION) == 'Profile.PRODUCTION'
+            assert repr(Profile.TEST) == 'Profile.TEST'
+            assert repr(Profile.DEVELOPMENT) == 'Profile.DEVELOPMENT'
+            assert repr(Profile.STAGING) == 'Profile.STAGING'
+            assert repr(Profile.CI) == 'Profile.CI'
+            assert repr(Profile.ALL) == 'Profile.ALL'
+
+        def it_preserves_custom_profile_str_value(self) -> None:
+            assert str(Profile('my-env')) == 'my-env'
+
+        def it_preserves_custom_profile_repr_value(self) -> None:
+            assert repr(Profile('my-env')) == "Profile('my-env')"
+
+        def it_still_matches_wildcard_internally(self) -> None:
+            assert Profile.ALL == '*'
+
+        def it_uses_display_name_in_format_spec(self) -> None:
+            assert f'{Profile.ALL:>10}' == '       ALL'
 
     class DescribeEquality:
         """Equality comparisons."""


### PR DESCRIPTION
## Summary

- Override `__str__`, `__repr__`, and `__format__` on `Profile` to display built-in profile constant names instead of raw internal values
- `str(Profile.ALL)` now returns `'ALL'` instead of `'*'`; `repr(Profile.ALL)` returns `'Profile.ALL'` instead of `"Profile('*')"`
- All built-in profiles (PRODUCTION, TEST, DEVELOPMENT, STAGING, CI, ALL) show clean display names while custom profiles retain their string values
- Fix duplicate TOML key in `pyproject.toml` that prevented `uv sync`

## Test plan

- [x] 9 new tests in `DescribeStringRepresentation` covering str, repr, format spec, f-string, and backward compatibility
- [x] Updated existing repr/str tests to expect new display format
- [x] Updated Container/ScopedContainer repr tests for new Profile repr output
- [x] All 686 tests pass (714 including benchmarks)
- [x] 100% coverage on `profile_enum.py`
- [x] BDD acceptance criteria from `@wip` scenario satisfied
- [x] mypy, ruff, isort all pass
- [x] Pre-commit hooks all pass

Fixes #387

Generated with [Claude Code](https://claude.ai/claude-code)