### PR TITLE
feat: Add deprecation warning infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,6 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "features/**/*.py" = ["S101", "PLC0415"]  # Allow assert, deferred imports in behave step definitions
 "tests/**/*.py" = ["S101", "B008", "PLC0415"]  # Allow assert, Inject() in defaults, local imports in tests
-"features/**/*.py" = ["PLC0415"]  # Allow local imports in behave step definitions
 "python/dioxide/container.py" = ["PLC0415"]  # Allow local imports in scan() to avoid circular dependencies
 "python/dioxide/decorators.py" = ["PLC0415"]  # Allow local imports to avoid circular dependencies
 "python/dioxide/fastapi.py" = ["PLC0415"]  # Allow local imports to avoid circular dependencies

--- a/python/dioxide/__init__.py
+++ b/python/dioxide/__init__.py
@@ -63,10 +63,12 @@ from .container import (
     container,
     reset_global_container,
 )
+from .deprecation import deprecated
 from .exceptions import (
     AdapterNotFoundError,
     CaptiveDependencyError,
     CircularDependencyError,
+    DioxideDeprecationWarning,
     DioxideError,
     ResolutionError,
     ScopeError,
@@ -84,6 +86,7 @@ __all__ = [
     'CaptiveDependencyError',
     'CircularDependencyError',
     'Container',
+    'DioxideDeprecationWarning',
     'DioxideError',
     'Profile',
     'ResolutionError',
@@ -95,6 +98,7 @@ __all__ = [
     '_get_registered_components',
     'adapter',
     'container',
+    'deprecated',
     'fresh_container',
     'lifecycle',
     'reset_global_container',

--- a/python/dioxide/deprecation.py
+++ b/python/dioxide/deprecation.py
@@ -1,0 +1,60 @@
+"""Deprecation warning infrastructure for dioxide.
+
+Provides the ``deprecated()`` decorator for marking functions and methods
+as deprecated with structured warning messages that include version
+information and migration guidance.
+"""
+
+from __future__ import annotations
+
+import functools
+import warnings
+from typing import (
+    TYPE_CHECKING,
+    TypeVar,
+)
+
+from dioxide.exceptions import DioxideDeprecationWarning
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    F = TypeVar('F', bound=Callable[..., object])
+
+
+def deprecated(
+    *,
+    since: str,
+    removed_in: str,
+    alternative: str | None = None,
+) -> Callable[[F], F]:
+    """Mark a function or method as deprecated.
+
+    Args:
+        since: The version when this was deprecated (e.g., '2.0.0').
+        removed_in: The version when this will be removed (e.g., '3.0.0').
+        alternative: What to use instead (e.g., 'str(profile)').
+
+    Returns:
+        A decorator that wraps the function to emit a DioxideDeprecationWarning
+        when called.
+    """
+
+    def decorator(func: F) -> F:
+        name = getattr(func, '__qualname__', func.__name__)
+        parts = [f'{name} is deprecated since v{since} and will be removed in v{removed_in}.']
+        if alternative:
+            parts.append(f'Use {alternative} instead.')
+        message = ' '.join(parts)
+
+        @functools.wraps(func)
+        def wrapper(*args: object, **kwargs: object) -> object:
+            warnings.warn(message, DioxideDeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+__all__ = ['deprecated']

--- a/python/dioxide/exceptions.py
+++ b/python/dioxide/exceptions.py
@@ -183,6 +183,23 @@ if TYPE_CHECKING:
 DOCS_BASE_URL = 'https://dioxide.readthedocs.io/en/stable'
 
 
+class DioxideDeprecationWarning(DeprecationWarning):
+    """Custom deprecation warning for dioxide APIs.
+
+    Using a dedicated warning subclass allows users to filter dioxide
+    deprecation warnings separately from other DeprecationWarning sources::
+
+        import warnings
+        from dioxide import DioxideDeprecationWarning
+
+        # Silence all dioxide deprecation warnings
+        warnings.filterwarnings('ignore', category=DioxideDeprecationWarning)
+
+        # Turn dioxide deprecation warnings into errors during testing
+        warnings.filterwarnings('error', category=DioxideDeprecationWarning)
+    """
+
+
 class DioxideError(Exception):
     """Base class for all dioxide errors with rich formatting.
 

--- a/tests/test_deprecation_infra.py
+++ b/tests/test_deprecation_infra.py
@@ -1,0 +1,196 @@
+"""Tests for deprecation warning infrastructure (#407)."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+
+class DescribeDioxideDeprecationWarning:
+    """DioxideDeprecationWarning is a custom warning class for dioxide deprecations."""
+
+    def it_is_importable_from_dioxide(self) -> None:
+        from dioxide import DioxideDeprecationWarning
+
+        assert DioxideDeprecationWarning is not None
+
+    def it_is_a_subclass_of_deprecation_warning(self) -> None:
+        from dioxide import DioxideDeprecationWarning
+
+        assert issubclass(DioxideDeprecationWarning, DeprecationWarning)
+
+    def it_can_be_filtered_separately_from_other_deprecation_warnings(self) -> None:
+        from dioxide import DioxideDeprecationWarning
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            warnings.filterwarnings('ignore', category=DioxideDeprecationWarning)
+
+            warnings.warn('dioxide thing', DioxideDeprecationWarning, stacklevel=1)
+            warnings.warn('other thing', DeprecationWarning, stacklevel=1)
+
+        assert len(caught) == 1
+        assert caught[0].category is DeprecationWarning
+        assert 'other thing' in str(caught[0].message)
+
+
+class DescribeDeprecatedDecorator:
+    """The deprecated() decorator marks functions/methods as deprecated."""
+
+    def it_is_importable_from_dioxide(self) -> None:
+        from dioxide import deprecated
+
+        assert callable(deprecated)
+
+    def it_emits_warning_when_decorated_function_is_called(self) -> None:
+        from dioxide import (
+            DioxideDeprecationWarning,
+            deprecated,
+        )
+
+        @deprecated(since='2.0.0', removed_in='3.0.0')
+        def old_function() -> str:
+            return 'result'
+
+        with pytest.warns(DioxideDeprecationWarning):
+            result = old_function()
+
+        assert result == 'result'
+
+    def it_includes_since_version_in_warning_message(self) -> None:
+        from dioxide import deprecated
+
+        @deprecated(since='2.0.0', removed_in='3.0.0')
+        def old_function() -> None:
+            pass
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            old_function()
+
+        assert len(caught) == 1
+        assert 'v2.0.0' in str(caught[0].message)
+
+    def it_includes_removed_in_version_in_warning_message(self) -> None:
+        from dioxide import deprecated
+
+        @deprecated(since='2.0.0', removed_in='3.0.0')
+        def old_function() -> None:
+            pass
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            old_function()
+
+        assert len(caught) == 1
+        assert 'v3.0.0' in str(caught[0].message)
+
+    def it_includes_alternative_in_warning_message(self) -> None:
+        from dioxide import deprecated
+
+        @deprecated(since='2.0.0', removed_in='3.0.0', alternative='new_function()')
+        def old_function() -> None:
+            pass
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            old_function()
+
+        assert len(caught) == 1
+        assert 'new_function()' in str(caught[0].message)
+
+    def it_includes_function_name_in_warning_message(self) -> None:
+        from dioxide import deprecated
+
+        @deprecated(since='2.0.0', removed_in='3.0.0')
+        def specific_old_function() -> None:
+            pass
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            specific_old_function()
+
+        assert len(caught) == 1
+        assert 'specific_old_function' in str(caught[0].message)
+
+    def it_omits_alternative_text_when_not_provided(self) -> None:
+        from dioxide import deprecated
+
+        @deprecated(since='2.0.0', removed_in='3.0.0')
+        def old_function() -> None:
+            pass
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            old_function()
+
+        assert len(caught) == 1
+        assert 'instead' not in str(caught[0].message)
+
+    def it_preserves_function_name(self) -> None:
+        from dioxide import deprecated
+
+        @deprecated(since='2.0.0', removed_in='3.0.0')
+        def old_function() -> None:
+            pass
+
+        assert old_function.__name__ == 'old_function'
+
+    def it_preserves_function_docstring(self) -> None:
+        from dioxide import deprecated
+
+        @deprecated(since='2.0.0', removed_in='3.0.0')
+        def old_function() -> None:
+            """Original docstring."""
+
+        assert old_function.__doc__ == 'Original docstring.'
+
+    def it_works_on_methods(self) -> None:
+        from dioxide import (
+            DioxideDeprecationWarning,
+            deprecated,
+        )
+
+        class MyClass:
+            @deprecated(since='1.0.0', removed_in='2.0.0', alternative='new_method()')
+            def old_method(self) -> str:
+                return 'method_result'
+
+        obj = MyClass()
+
+        with pytest.warns(DioxideDeprecationWarning, match='old_method'):
+            result = obj.old_method()
+
+        assert result == 'method_result'
+
+    def it_uses_dioxide_deprecation_warning_category(self) -> None:
+        from dioxide import (
+            DioxideDeprecationWarning,
+            deprecated,
+        )
+
+        @deprecated(since='2.0.0', removed_in='3.0.0')
+        def old_function() -> None:
+            pass
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            old_function()
+
+        assert len(caught) == 1
+        assert caught[0].category is DioxideDeprecationWarning
+
+    def it_points_warning_to_caller_not_decorator(self) -> None:
+        from dioxide import deprecated
+
+        @deprecated(since='2.0.0', removed_in='3.0.0')
+        def old_function() -> None:
+            pass
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            old_function()
+
+        assert len(caught) == 1
+        assert 'test_deprecation_infra.py' in caught[0].filename


### PR DESCRIPTION
## Summary

- Add `DioxideDeprecationWarning` custom warning class (subclass of `DeprecationWarning`) so users can filter dioxide deprecation warnings separately from other libraries
- Add `deprecated()` decorator that accepts `since`, `removed_in`, and `alternative` parameters for consistent, structured deprecation messages
- Warning messages include function name, version info, and optional migration guidance
- Warning stacklevel points to caller code, not dioxide internals
- Fix duplicate key in pyproject.toml ruff per-file-ignores

## Usage

```python
from dioxide import deprecated, DioxideDeprecationWarning

# Mark a function as deprecated
@deprecated(since='2.0.0', removed_in='3.0.0', alternative='new_function()')
def old_function():
    ...

# Users can filter dioxide-specific deprecation warnings
import warnings
warnings.filterwarnings('ignore', category=DioxideDeprecationWarning)
```

## Test plan

- [x] 15 tests covering warning class, decorator, message content, filtering, metadata preservation, method support, and stacklevel
- [x] 100% coverage on `deprecation.py`
- [x] Full test suite passes (718 passed, 5 skipped)
- [x] ruff format/check clean
- [x] mypy clean
- [x] All pre-commit hooks pass

Fixes #407

Generated with [Claude Code](https://claude.ai/claude-code)