### PR TITLE
chore: add uv run python guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,7 @@ Key conventions:
 - Use **uv** for Python tooling: `uv run`, `uv sync`, `uv add`
 - Do NOT use `uv pip` commands
 - Use groups/extras where appropriate: `uv sync --group dev`
+- **NEVER use bare `python` or `python3`** — always use `uv run python`. Bare `python` resolves to system Python which has a stale dioxide install without recent features. This applies to scripts, one-liners (`python -c "..."`), and agent verification commands. The `lights-on-uv.sh` AYLO hook enforces this at the decision boundary.
 
 ## Profile Class API
 


### PR DESCRIPTION
## Summary

- Adds explicit warning to CLAUDE.md Tool Usage section: never use bare `python`/`python3`, always use `uv run python`
- Documents the `lights-on-uv.sh` AYLO hook that enforces this at the decision boundary

Bare `python` resolves to system Python which has a stale dioxide install missing recent features (e.g., `Scope.REQUEST`, `profile` param). This caused a false positive during PR #476 review.

## Test plan

- [x] Documentation-only change, no code affected
- [x] Pre-commit hooks pass

Fixes #480

Generated with [Claude Code](https://claude.ai/claude-code)