### PR TITLE
docs: replace broken links with stable alternatives (#492)

### DIFF
--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -1794,7 +1794,7 @@ For a deeper dive with before/after examples, see {doc}`Migration from Mocks <mi
 
 - [Martin Fowler: Mocks Aren't Stubs](https://martinfowler.com/articles/mocksArentStubs.html)
 - [Test Doubles (Meszaros)](http://xunitpatterns.com/Test%20Double.html)
-- [Hexagonal Architecture](https://alistair.cockburn.us/hexagonal-architecture/)
+- [Hexagonal Architecture](https://en.wikipedia.org/wiki/Hexagonal_architecture_(software))
 
 ---
 

--- a/docs/design/ADR-lifecycle-evaluation.md
+++ b/docs/design/ADR-lifecycle-evaluation.md
@@ -267,7 +267,7 @@ Medium-weight criteria (multiplied by 2): Zero Ceremony, Type Safety, Testing, I
 
 The approach aligns with established patterns in the Python DI ecosystem:
 
-- [dependency-injector](https://python-dependency-injector.ets-labs.org/) uses a `Resource` provider
+- [dependency-injector](https://github.com/ets-labs/python-dependency-injector) uses a `Resource` provider
   type with explicit `init`/`shutdown` methods -- separate from the provider registration mechanism.
 - FastAPI's lifespan handler uses explicit `startup`/`shutdown` callbacks, not implicit protocol detection.
 - Django uses explicit signal-based lifecycle (`pre_init`, `post_init`, `pre_save`, etc.).
@@ -332,7 +332,7 @@ It should only be pursued if there is demonstrated user demand, not speculativel
 - [Dioxide Design Principles](../design-principles.md) -- Canonical design reference
 - [ADR-001: Container Architecture](ADR-001-container-architecture.md) -- Container design decisions
 - [GitHub Issue #388](https://github.com/mikelane/dioxide/issues/388) -- Original spike issue
-- [Python dependency-injector](https://python-dependency-injector.ets-labs.org/) -- Resource provider pattern
+- [Python dependency-injector](https://github.com/ets-labs/python-dependency-injector) -- Resource provider pattern
 - [.NET IDisposable Pattern](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose) -- Inspiration for `dispose` naming
 
 ---

--- a/docs/testing/index.rst
+++ b/docs/testing/index.rst
@@ -94,4 +94,4 @@ External Resources
 
 - `Martin Fowler: Mocks Aren't Stubs <https://martinfowler.com/articles/mocksArentStubs.html>`_
 - `Test Doubles (Meszaros) <http://xunitpatterns.com/Test%20Double.html>`_
-- `Hexagonal Architecture <https://alistair.cockburn.us/hexagonal-architecture/>`_
+- `Hexagonal Architecture <https://en.wikipedia.org/wiki/Hexagonal_architecture_(software)>`_

--- a/docs/user_guide/testing_with_fakes.rst
+++ b/docs/user_guide/testing_with_fakes.rst
@@ -1463,7 +1463,7 @@ External Resources
 
 - `Martin Fowler: Mocks Aren't Stubs <https://martinfowler.com/articles/mocksArentStubs.html>`_
 - `Test Doubles (Meszaros) <http://xunitpatterns.com/Test%20Double.html>`_
-- `Hexagonal Architecture <https://alistair.cockburn.us/hexagonal-architecture/>`_
+- `Hexagonal Architecture <https://en.wikipedia.org/wiki/Hexagonal_architecture_(software)>`_
 
 ----
 


### PR DESCRIPTION
## Summary
- Replace 2 expired `ets-labs.org` links with the GitHub repo
- Replace 3 expired `alistair.cockburn.us` links with Wikipedia
- Both domains have expired SSL certificates, breaking the doc-links CI check

## Test plan
- [x] `sphinx-build -b linkcheck` exits 0 locally (was exit 1 with broken links)
- [x] No other broken links detected

Fixes #492